### PR TITLE
Jlso - monitorización de instancias ec2(backend, frontend) con terraform y datadog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,22 @@ yarn-error.log*
 .vscode
 
 # .env
+.env
+
+# Archivos de estado de Terraform
+*.tfstate
+*.tfstate.*
+
+# Archivos de variables con información sensible
+*.tfvars
+*.tfvars.json
+
+# Archivos de registro
+crash.log
+crash.*.log
+
+# Archivos de override
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/prompts/README-JLSO.md
+++ b/prompts/README-JLSO.md
@@ -1,6 +1,6 @@
-# Configuración de Terraform para Monitoreo con Datadog
+# Configuración de Monitorización con Datadog para AWS EC2
 
-Este documento describe la configuración de Terraform utilizada en este proyecto, los retos enfrentados durante la implementación y las soluciones aplicadas.
+Este proyecto configura la monitorización de instancias EC2 en AWS utilizando Datadog a través de Terraform.
 
 ## Estructura del Proyecto
 
@@ -20,6 +20,122 @@ El proyecto utiliza Terraform para aprovisionar y gestionar infraestructura en A
 - `security_groups.tf`: Configuración de grupos de seguridad
 - `iam.tf`: Configuración de políticas y roles IAM
 - `scripts/`: Scripts de inicialización para instancias EC2
+
+## Estructura del Proyecto
+
+- `main.tf`: Configuración principal de Terraform y proveedores
+- `ec2.tf`: Definición de instancias EC2
+- `s3.tf`: Configuración del bucket S3 y objetos
+- `security_groups.tf`: Definición de grupos de seguridad
+- `iam.tf`: Configuración de roles y políticas IAM
+- `monitors.tf`: Definición de monitores y alertas de Datadog
+- `variables.tf`: Definición de variables para la configuración
+- `scripts/`: Scripts de inicialización para instancias EC2
+
+## Componentes de Monitorización
+
+### 1. Integración de Datadog con AWS
+
+Se ha configurado una política IAM que permite a Datadog acceder a métricas de CloudWatch y otros recursos de AWS. Esta política incluye permisos para:
+
+- Acceso a métricas de CloudWatch
+- Descripción de instancias EC2
+- Acceso a logs
+- Acceso a CloudTrail
+- Acceso a AWS Health
+
+### 2. Agente Datadog en Instancias EC2
+
+El agente Datadog se instala automáticamente en las instancias EC2 a través de scripts de inicialización. La configuración incluye:
+
+- Recopilación de métricas del sistema (CPU, memoria, disco, red)
+- Recopilación de logs
+- Monitorización de procesos
+- Integración con Docker
+- Recopilación de etiquetas EC2
+
+### 3. Dashboard de Datadog
+
+Se ha creado un dashboard completo en Datadog que incluye:
+
+- Métricas de CPU (utilización, créditos)
+- Métricas de memoria
+- Métricas de red (tráfico entrante/saliente, paquetes)
+- Métricas de disco (lectura/escritura, uso)
+- Lista de las instancias con mayor uso de CPU
+
+### 4. Monitores y Alertas
+
+Se han configurado varios monitores para alertar sobre problemas potenciales:
+
+- Alta utilización de CPU (>80%)
+- Alta utilización de memoria (>85%)
+- Alto uso de disco (>85%)
+- Instancias EC2 no disponibles
+- Errores en logs de aplicación
+
+## Requisitos
+
+- Terraform >= 0.14
+- Cuenta de AWS con permisos adecuados
+- Cuenta de Datadog con API key y Application key
+
+## Uso
+
+1. Configura las variables de entorno o crea un archivo `.env` con las siguientes variables:
+
+   ```
+   TF_VAR_datadog_api_key=<tu_api_key>
+   TF_VAR_datadog_app_key=<tu_app_key>
+   ```
+
+2. Inicializa Terraform:
+
+   ```
+   terraform init
+   ```
+
+3. Planifica los cambios:
+
+   ```
+   terraform plan
+   ```
+
+4. Aplica la configuración:
+   ```
+   terraform apply
+   ```
+
+## Personalización
+
+Puedes personalizar la configuración modificando las variables en `variables.tf` o proporcionando valores diferentes al ejecutar `terraform apply`:
+
+```
+terraform apply -var="environment=staging" -var="team=devops"
+```
+
+## Consideraciones de Seguridad
+
+- Las claves API de Datadog se manejan como variables sensibles
+- Se recomienda utilizar AWS Secrets Manager o Parameter Store para almacenar secretos en producción
+- Los scripts de inicialización obtienen las credenciales de forma segura desde un archivo `.env` almacenado en S3
+
+## Mantenimiento
+
+Para actualizar la configuración:
+
+1. Modifica los archivos de Terraform según sea necesario
+2. Ejecuta `terraform plan` para verificar los cambios
+3. Ejecuta `terraform apply` para aplicar los cambios
+
+## Troubleshooting
+
+Si el agente Datadog no está enviando métricas:
+
+1. Verifica que las instancias EC2 tengan acceso a Internet
+2. Comprueba los logs del agente: `/var/log/datadog/agent.log`
+3. Asegúrate de que la política IAM tenga los permisos correctos
+4. Verifica que las claves API sean válidas
 
 ## Retos Enfrentados y Soluciones
 

--- a/prompts/README-JLSO.md
+++ b/prompts/README-JLSO.md
@@ -1,0 +1,145 @@
+# Configuración de Terraform para Monitoreo con Datadog
+
+Este documento describe la configuración de Terraform utilizada en este proyecto, los retos enfrentados durante la implementación y las soluciones aplicadas.
+
+## Estructura del Proyecto
+
+El proyecto utiliza Terraform para aprovisionar y gestionar infraestructura en AWS, incluyendo:
+
+- Bucket S3 para almacenar archivos de código
+- Instancias EC2 para frontend y backend
+- Grupos de seguridad
+- Políticas IAM
+- Dashboard de Datadog para monitoreo
+
+## Archivos Principales
+
+- `main.tf`: Configuración principal de Terraform y proveedores
+- `s3.tf`: Configuración del bucket S3 y objetos
+- `ec2.tf`: Configuración de instancias EC2
+- `security_groups.tf`: Configuración de grupos de seguridad
+- `iam.tf`: Configuración de políticas y roles IAM
+- `scripts/`: Scripts de inicialización para instancias EC2
+
+## Retos Enfrentados y Soluciones
+
+### 1. Conflictos de Nombres de Recursos
+
+**Problema**: Al intentar aplicar la configuración, se encontraron errores porque algunos recursos ya existían con los mismos nombres en AWS.
+
+**Solución**: Se modificaron los nombres de los recursos añadiendo un sufijo único (`-jlso`) para evitar conflictos:
+
+```terraform
+# Antes
+resource "aws_iam_policy" "datadog_policy" {
+  name = "DatadogPolicy"
+  # ...
+}
+
+# Después
+resource "aws_iam_policy" "datadog_policy" {
+  name = "DatadogPolicy-jlso"
+  # ...
+}
+```
+
+Recursos modificados:
+
+- Política IAM: `DatadogPolicy-jlso`
+- Grupos de seguridad: `lti-project-backend-sg-jlso` y `lti-project-frontend-sg-jlso`
+- Bucket S3: `lti-project-code-bucket-jlso`
+
+### 2. Problemas con ACL del Bucket S3
+
+**Problema**: Error al crear el ACL del bucket S3 debido a que los buckets S3 modernos no permiten ACLs por defecto.
+
+```
+Error: error creating S3 bucket ACL: AccessControlListNotSupported: The bucket does not allow ACLs
+```
+
+**Solución**: Se reemplazó el recurso `aws_s3_bucket_acl` por `aws_s3_bucket_ownership_controls` para configurar la propiedad de objetos:
+
+```terraform
+resource "aws_s3_bucket_ownership_controls" "code_bucket_ownership" {
+  bucket = aws_s3_bucket.code_bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+```
+
+### 3. Recursos Obsoletos en el Estado de Terraform
+
+**Problema**: Errores al intentar aplicar cambios debido a recursos obsoletos en el estado de Terraform.
+
+**Solución**: Se limpiaron los recursos obsoletos del estado:
+
+```bash
+terraform state rm aws_s3_bucket_object.backend_zip aws_s3_bucket_object.frontend_zip
+```
+
+Y se actualizaron a los recursos modernos:
+
+```terraform
+resource "aws_s3_object" "backend_zip" {
+  # Configuración actualizada
+}
+```
+
+### 4. Manejo de Información Sensible
+
+**Problema**: Claves API y secretos hardcodeados en scripts y configuraciones.
+
+**Solución**:
+
+1. Se marcaron las variables sensibles en Terraform:
+
+   ```terraform
+   variable "datadog_api_key" {
+     sensitive = true
+     # ...
+   }
+   ```
+
+2. Se excluyeron archivos sensibles del control de versiones en `.gitignore`:
+
+   ```
+   # Scripts con información sensible
+   tf/scripts/backend_user_data.sh
+   tf/scripts/frontend_user_data.sh
+
+   # Archivos de estado y variables
+   *.tfstate
+   *.tfstate.*
+   *.tfvars
+   .env
+   ```
+
+## Proceso de Despliegue
+
+Para desplegar esta infraestructura:
+
+1. Asegúrate de tener las credenciales de AWS configuradas
+2. Crea un archivo `.env` con las variables necesarias
+3. Inicializa Terraform:
+   ```bash
+   cd tf
+   terraform init
+   ```
+4. Planifica los cambios:
+   ```bash
+   terraform plan
+   ```
+5. Aplica la configuración:
+   ```bash
+   terraform apply
+   ```
+
+## Resumen de retos enfrentados
+
+- Entender la configuración de terraform
+- Que hay que tener cuidado con los nombres de los recursos, ya que deben ser únicos en todo aws
+- Problemas con ACL del Bucket S3
+- Recursos obsoletos en el estado de Terraform
+- Manejo de información sensible
+- Se implementó un enfoque de primero hacer que lo que ya estaba configurado funcione, para luego empezar a configurar el monitoreo con datadog, el cual será el siguiente paso.

--- a/prompts/README-JLSO.md
+++ b/prompts/README-JLSO.md
@@ -231,6 +231,98 @@ resource "aws_s3_object" "backend_zip" {
    .env
    ```
 
+### 5. Problemas con la Configuración de Datadog
+
+**Problema**: Errores de declaración de variables duplicadas al integrar Datadog.
+
+**Prompt utilizado**:
+
+```
+i have these errors with the new configuration, some duplicate variable declarations. fix the errors
+```
+
+**Solución**: Se eliminaron las declaraciones duplicadas de variables en `main.tf` y se dejaron solo las definiciones en `variables.tf`:
+
+```terraform
+// Removing duplicate variable declarations as they are defined in variables.tf
+// variable "datadog_api_key" {
+//   description = "API Key para Datadog"
+//   type        = string
+// }
+```
+
+### 6. Problemas con la Recolección de Métricas de CPU
+
+**Problema**: Las métricas de CPU no aparecían en el dashboard de Datadog a pesar de que el agente estaba instalado y funcionando.
+
+**Prompt utilizado**:
+
+```
+Estoy ejecutando el comando `sudo datadog-agent status | grep -i "system\|core\|cpu\|collector"` y veo que el collector no está funcionando. ¿Qué podría estar causando este problema y cómo puedo solucionarlo?
+```
+
+**Solución**: Se identificó que el collector y el system probe no estaban funcionando. Se implementaron las siguientes correcciones:
+
+1. Se verificó y corrigió la configuración en `/etc/datadog-agent/datadog.yaml`:
+
+   ```yaml
+   collect_ec2_tags: true
+   system_probe_config:
+     enabled: true
+   ```
+
+2. Se creó un archivo de configuración específico para CPU:
+
+   ```yaml
+   # /etc/datadog-agent/conf.d/cpu.d/conf.yaml
+   init_config:
+
+   instances:
+     - {}
+   ```
+
+3. Se reiniciaron los servicios de Datadog:
+   ```bash
+   systemctl restart datadog-agent
+   systemctl restart datadog-agent-sysprobe
+   ```
+
+### 7. Problemas de Conectividad con Datadog
+
+**Problema**: Errores al intentar validar la conectividad con Datadog.
+
+**Prompt utilizado**:
+
+```
+Estoy intentando validar la conectividad con Datadog usando `curl -Is https://api.datadoghq.com/api/v1/validate | head -1` pero recibo un error 404. ¿Qué podría estar mal?
+```
+
+**Solución**: Se identificó que la URL de validación era incorrecta. Se corrigió utilizando el endpoint correcto:
+
+```bash
+curl -Is https://intake.datadoghq.com/api/v1/validate | head -1
+```
+
+### 8. Necesidad de Scripts de Diagnóstico y Pruebas
+
+**Problema**: Dificultad para diagnosticar problemas con el agente Datadog y verificar que las métricas se estaban recopilando correctamente.
+
+**Prompt utilizado**:
+
+```
+Necesito un script de diagnóstico completo que verifique todos los aspectos de la configuración de Datadog: instalación del agente, configuración, permisos, conectividad, etc. El script debe generar un informe detallado con los resultados.
+```
+
+**Solución**: Se crearon varios scripts para diagnóstico y pruebas:
+
+1. `validate_datadog_permissions.sh`: Verifica permisos y configuración del agente
+2. `datadog_diagnostics.sh`: Realiza un diagnóstico completo y genera un informe
+3. `stress_test.sh`: Genera carga en CPU para verificar la recolección de métricas
+4. `full_stress_test.sh`: Genera carga en CPU, memoria y disco
+5. `monitor_cpu.sh`: Monitorea el uso de CPU en tiempo real
+6. `upload_stress_tools.sh`: Sube las herramientas de prueba a las instancias EC2
+7. `remote_stress_test.sh`: Ejecuta pruebas de estrés remotamente
+
 ## Proceso de Despliegue
 
 Para desplegar esta infraestructura:
@@ -258,4 +350,9 @@ Para desplegar esta infraestructura:
 - Problemas con ACL del Bucket S3
 - Recursos obsoletos en el estado de Terraform
 - Manejo de información sensible
-- Se implementó un enfoque de primero hacer que lo que ya estaba configurado funcione, para luego empezar a configurar el monitoreo con datadog, el cual será el siguiente paso.
+- Configuración correcta del agente Datadog para recopilar métricas de CPU
+- Problemas de conectividad con la API de Datadog
+- Necesidad de scripts de diagnóstico y pruebas para verificar la configuración
+- Configuración de monitores y alertas efectivas
+- Optimización de la recopilación de métricas para reducir costos
+- Automatización de la respuesta a alertas comunes

--- a/prompts/datadog-aws-prompts-JLSO.md
+++ b/prompts/datadog-aws-prompts-JLSO.md
@@ -1,0 +1,241 @@
+# Prompts Utilizados para Configuración de Terraform con AWS y Datadog
+
+Este documento recopila los prompts clave utilizados durante la configuración de Terraform para el proyecto de monitoreo con AWS y Datadog. Estos prompts pueden servir como referencia para resolver problemas similares en el futuro. Este documento se va a dividir en 2 fases, la primera es la de contexto de la configuración inicial base que tenía el proyecto, y la segunda es la de la configuración de monitoreo con datadog.
+
+## Tabla de Contenidos
+
+### Fase 1: Contexto de la Configuración Inicial Base
+
+- [Contexto de la Configuración Inicial Base](#contexto-de-la-configuración-inicial-base)
+- [Diagnóstico de Errores](#diagnóstico-de-errores)
+  - [Errores de Recursos Duplicados](#errores-de-recursos-duplicados)
+  - [Manejo de Recursos en Diferentes Cuentas](#manejo-de-recursos-en-diferentes-cuentas)
+- [Solución de Problemas](#solución-de-problemas)
+  - [Modificación de Nombres de Recursos](#modificación-de-nombres-de-recursos)
+  - [Ejecución de Scripts](#ejecución-de-scripts)
+- [Seguridad y Buenas Prácticas](#seguridad-y-buenas-prácticas)
+  - [Identificación de Información Sensible](#identificación-de-información-sensible)
+  - [Manejo Seguro de Secretos](#manejo-seguro-de-secretos)
+- [Documentación](#documentación)
+- [Comandos Clave de Terraform](#comandos-clave-de-terraform)
+- [Lecciones Aprendidas](#lecciones-aprendidas)
+
+### Fase 2: Configuración de Monitoreo con Datadog
+
+- [Integración de Datadog con AWS](#integración-de-datadog-con-aws)
+- [Configuración de Dashboards](#configuración-de-dashboards)
+- [Configuración de Alertas](#configuración-de-alertas)
+- [Pruebas de Monitoreo](#pruebas-de-monitoreo)
+- [Optimización de Costos](#optimización-de-costos)
+- [Troubleshooting](#troubleshooting)
+- [Conclusiones y Próximos Pasos](#conclusiones-y-próximos-pasos)
+
+## Fase 1: Contexto de la Configuración Inicial Base
+
+### Contexto de la Configuración Inicial Base
+
+```
+Explícame la configuración actual de @tf, y cual es el proposito o el resultado que se busca con esta configuración
+```
+
+Este prompt me ayudó a entender la configuración actual de @tf, y cual es el proposito o el resultado que se busca con esta configuración.
+
+### Diagnóstico de Errores
+
+### Errores de Recursos Duplicados
+
+```
+now i am facing this errros after apply
+```
+
+Este prompt se utilizó cuando aparecieron errores de recursos duplicados durante la ejecución de `terraform apply`. Los errores incluían:
+
+- Política IAM "DatadogPolicy" ya existente
+- Grupos de seguridad duplicados
+- Problemas con ACL del bucket S3
+
+### Manejo de Recursos en Diferentes Cuentas
+
+```
+antes de ejecutar este import, es importante saber que es posible que otro usuario haya creado estas configuraciones para su propia cuenta de aws, yo estoy creando la mia propia para mi usuario, el cual está desconectado de la otra cuenta de aws. debería comenzar con un estado vacio o que me recomiendas?
+```
+
+Este prompt fue crucial para entender que estábamos trabajando con una cuenta AWS independiente y que necesitábamos modificar los nombres de los recursos en lugar de importarlos.
+
+## Solución de Problemas
+
+### Modificación de Nombres de Recursos
+
+Después de identificar los conflictos de nombres, se utilizaron prompts para modificar los recursos:
+
+```
+ahora despues de hacer los ajuestes en los nombre cuales son los pasos a seguir?
+```
+
+Este prompt nos llevó a ejecutar `terraform plan` para verificar los cambios y prepararnos para aplicarlos.
+
+### Ejecución de Scripts
+
+```
+yo veo que en el archivo @s3.tf se ejecuta el generar-zip.sh, es necesario ejecutarlo manualmente? o solo con el apply funcionaría?. @tf aquí está toda la configuración de terraform
+```
+
+Este prompt ayudó a aclarar que el script `generar-zip.sh` se ejecuta automáticamente a través del recurso `null_resource` en Terraform.
+
+## Seguridad y Buenas Prácticas
+
+### Identificación de Información Sensible
+
+```
+de los archivos modificados en @tf que información sencible debería omitir en un commit?
+```
+
+Este prompt nos permitió identificar información sensible en la configuración:
+
+- Claves API de Datadog en scripts de user_data
+- Archivos de estado de Terraform
+- Variables con información sensible
+
+### Manejo Seguro de Secretos
+
+```
+en los scripts sh de backend y frontend me gustaría que obtuvieran esos datos de forma segura, en posible importarlos del archivo .env?
+```
+
+Este prompt llevó a la implementación de una solución para cargar variables sensibles desde un archivo `.env` en lugar de hardcodearlas en los scripts.
+
+```
+voy a obtar por no incluir esos scripts en el commit
+```
+
+Este prompt resultó en la actualización del archivo `.gitignore` para excluir los scripts con información sensible del control de versiones.
+
+## Documentación
+
+```
+en este archivo @README.md documenta los pasos realizados para entender la configuración de terraform que está actualmente en el proyecto, y todos los retos que se tuvieron para poder configurar todo para mi usuario de aws, como el cambio de nombres etc, documenta este script también
+```
+
+Este prompt llevó a la creación de documentación detallada sobre la configuración de Terraform, los retos enfrentados y las soluciones implementadas.
+
+## Comandos Clave de Terraform
+
+Durante la conversación, se utilizaron varios comandos clave de Terraform:
+
+```bash
+# Inicializar Terraform
+terraform init
+
+# Ver el estado actual
+terraform state list
+
+# Eliminar recursos obsoletos del estado
+terraform state rm aws_s3_bucket_object.backend_zip aws_s3_bucket_object.frontend_zip
+
+# Planificar cambios
+terraform plan
+
+# Aplicar cambios
+terraform apply
+```
+
+## Lecciones Aprendidas
+
+1. **Nombres únicos**: Utilizar sufijos o prefijos únicos para evitar conflictos de nombres en recursos AWS.
+2. **Actualizaciones de API**: Estar atento a cambios en las APIs de AWS (como el cambio de `aws_s3_bucket_object` a `aws_s3_object`).
+3. **Manejo de secretos**: No hardcodear secretos en scripts o configuraciones.
+4. **Control de versiones**: Excluir archivos sensibles del control de versiones.
+5. **Documentación**: Documentar los retos y soluciones para referencia futura.
+
+## Fase 2: Configuración de Monitoreo con Datadog
+
+### Integración de Datadog con AWS
+
+```
+¿Cómo puedo integrar Datadog con mi infraestructura AWS gestionada por Terraform?
+```
+
+Este prompt me ayudó a entender cómo configurar la integración entre Datadog y AWS utilizando Terraform, incluyendo la creación de políticas IAM necesarias y la configuración del agente Datadog.
+
+```
+¿Qué permisos necesita Datadog para monitorear mis recursos AWS?
+```
+
+Este prompt me permitió identificar los permisos específicos que Datadog necesita para acceder a métricas de CloudWatch, logs y otros recursos de AWS.
+
+### Configuración de Dashboards
+
+```
+¿Cómo puedo crear un dashboard en Datadog para monitorear mis instancias EC2 usando Terraform?
+```
+
+Este prompt me guió en la creación de dashboards de Datadog utilizando Terraform, incluyendo la configuración de widgets para métricas como CPU, memoria y red.
+
+```
+¿Qué métricas son importantes monitorear para aplicaciones en contenedores Docker?
+```
+
+Este prompt me ayudó a identificar las métricas clave para monitorear aplicaciones en contenedores Docker, como uso de CPU, memoria, E/S de disco y red.
+
+### Configuración de Alertas
+
+```
+¿Cómo puedo configurar alertas en Datadog para notificarme cuando el uso de CPU supere cierto umbral?
+```
+
+Este prompt me mostró cómo configurar alertas basadas en umbrales para métricas críticas como el uso de CPU.
+
+```
+¿Cuáles son las mejores prácticas para configurar alertas y evitar falsos positivos?
+```
+
+Este prompt me proporcionó información sobre las mejores prácticas para configurar alertas efectivas, incluyendo la configuración de umbrales adecuados y períodos de evaluación.
+
+### Pruebas de Monitoreo
+
+```
+¿Cómo puedo probar que mis alertas de Datadog funcionan correctamente?
+```
+
+Este prompt me ayudó a entender cómo probar las alertas configuradas para asegurarme de que funcionan como se espera.
+
+```
+¿Cómo puedo simular una carga alta en mis instancias EC2 para probar las alertas?
+```
+
+Este prompt me proporcionó métodos para generar carga artificial en instancias EC2 y probar las alertas de Datadog.
+
+### Optimización de Costos
+
+```
+¿Cómo puedo optimizar los costos de Datadog mientras mantengo un monitoreo efectivo?
+```
+
+Este prompt me ayudó a entender estrategias para optimizar los costos de Datadog, como ajustar la frecuencia de recopilación de métricas y filtrar logs innecesarios.
+
+### Troubleshooting
+
+```
+El agente de Datadog no está enviando métricas desde mis instancias EC2, ¿cómo puedo solucionar este problema?
+```
+
+Este prompt me guió en la resolución de problemas comunes con el agente de Datadog, incluyendo verificación de conectividad, permisos y configuración.
+
+## Conclusiones y Próximos Pasos
+
+La configuración de Terraform con AWS y Datadog ha sido un proceso de aprendizaje valioso que ha requerido superar varios desafíos técnicos. Los principales aprendizajes incluyen:
+
+1. **Infraestructura como código**: La importancia de gestionar la infraestructura utilizando herramientas como Terraform para garantizar la reproducibilidad y consistencia.
+
+2. **Monitoreo proactivo**: La configuración de Datadog nos permite detectar problemas antes de que afecten a los usuarios finales.
+
+3. **Seguridad**: La implementación de prácticas seguras para el manejo de credenciales y secretos es fundamental.
+
+4. **Documentación**: Documentar los procesos, desafíos y soluciones facilita el mantenimiento futuro y la transferencia de conocimiento.
+
+### Próximos Pasos
+
+1. Implementar monitoreo más detallado a nivel de aplicación
+2. Configurar alertas adicionales para otros componentes críticos
+3. Explorar funcionalidades avanzadas de Datadog como APM (Application Performance Monitoring)
+4. Automatizar más aspectos de la configuración de monitoreo

--- a/prompts/datadog-aws-prompts-JLSO.md
+++ b/prompts/datadog-aws-prompts-JLSO.md
@@ -166,3 +166,96 @@ explícame que estas haciendo en cada paso de la configuración
 ```
 i have these errors with the new configuration, some duplicate variable declarations. fix the errors
 ```
+
+### Configuración de Dashboards
+
+```
+Ahora necesito que me ayudes a configurar un dashboard en Datadog para monitorear las instancias EC2. El dashboard debe incluir:
+- Métricas de CPU (utilización, créditos)
+- Métricas de memoria
+- Métricas de red (tráfico entrante/saliente, paquetes)
+- Métricas de disco (lectura/escritura, uso)
+- Lista de las instancias con mayor uso de CPU
+```
+
+```
+Necesito agregar monitores para alertar sobre problemas potenciales en las instancias EC2. Por favor, configura monitores para:
+- Alta utilización de CPU (>80%)
+- Alta utilización de memoria (>85%)
+- Alto uso de disco (>85%)
+- Instancias EC2 no disponibles
+```
+
+### Configuración de Alertas
+
+```
+Quiero configurar notificaciones para las alertas. ¿Cómo puedo hacer que las alertas se envíen a un canal de Slack y a un correo electrónico?
+```
+
+```
+Necesito que las alertas incluyan información detallada sobre el problema, como la instancia afectada, la métrica que causó la alerta y posibles acciones a tomar. ¿Cómo puedo personalizar los mensajes de alerta?
+```
+
+### Pruebas de Monitoreo
+
+```
+Necesito una forma de probar que las métricas se están recopilando correctamente. ¿Puedes crear un script que genere carga en la CPU para verificar que las métricas se envían a Datadog?
+```
+
+```
+Quiero un script más completo que pueda generar carga en CPU, memoria y disco para probar todas las métricas. El script debe permitir especificar la duración e intensidad de la carga.
+```
+
+```
+Necesito un script para monitorear el uso de CPU en tiempo real mientras ejecuto las pruebas de carga. El script debe mostrar el uso de CPU, carga del sistema, uso de memoria y swap.
+```
+
+```
+Necesito un script para subir las herramientas de prueba de estrés a las instancias EC2. El script debe transferir los scripts a las instancias backend y frontend.
+```
+
+```
+Quiero un script que me permita ejecutar pruebas de estrés remotamente en las instancias EC2 sin tener que conectarme directamente a ellas. El script debe permitir especificar el tipo de instancia (backend, frontend, ambas), el tipo de prueba (CPU, memoria, disco, todas), la duración y la intensidad.
+```
+
+### Troubleshooting
+
+```
+¿Cómo puedo validar si Datadog tiene los permisos necesarios para acceder a los logs de CPU desde la consola de AWS de cada instancia EC2?
+```
+
+```
+Necesito un script de diagnóstico completo que verifique todos los aspectos de la configuración de Datadog: instalación del agente, configuración, permisos, conectividad, etc. El script debe generar un informe detallado con los resultados.
+```
+
+```
+Estoy ejecutando el comando `sudo datadog-agent status | grep -i "system\|core\|cpu\|collector"` y veo que el collector no está funcionando. ¿Qué podría estar causando este problema y cómo puedo solucionarlo?
+```
+
+```
+He ejecutado `sudo datadog-agent check cpu` y veo que el check está funcionando correctamente, pero no veo las métricas de CPU en el dashboard de Datadog. ¿Qué podría estar causando este problema?
+```
+
+```
+Estoy intentando validar la conectividad con Datadog usando `curl -Is https://api.datadoghq.com/api/v1/validate | head -1` pero recibo un error 404. ¿Qué podría estar mal?
+```
+
+### Optimización de Costos
+
+```
+¿Cómo puedo optimizar los costos de la integración de Datadog con AWS? ¿Hay alguna configuración que pueda ajustar para reducir los costos sin sacrificar la calidad del monitoreo?
+```
+
+```
+¿Qué métricas son las más importantes para monitorear en las instancias EC2? Quiero asegurarme de que estoy recopilando las métricas esenciales sin gastar recursos en métricas que no son críticas.
+```
+
+### Conclusiones y Próximos Pasos
+
+```
+Ahora que tengo la configuración básica de monitoreo con Datadog, ¿cuáles serían los próximos pasos para mejorar la observabilidad de mi infraestructura? ¿Qué otras integraciones o configuraciones recomiendas?
+```
+
+```
+¿Cómo puedo automatizar la respuesta a alertas comunes? Por ejemplo, si una instancia tiene alta utilización de CPU, ¿puedo configurar una acción automática para escalar horizontalmente?
+```

--- a/prompts/datadog-aws-prompts-JLSO.md
+++ b/prompts/datadog-aws-prompts-JLSO.md
@@ -152,90 +152,17 @@ terraform apply
 ### Integración de Datadog con AWS
 
 ```
-¿Cómo puedo integrar Datadog con mi infraestructura AWS gestionada por Terraform?
+@tf Eres un Site Reliability Engineer en infraestructura, tu especialidad es el area de monitorizacion y observabilidad. Para esta ocasión se te ha solicitado que generes un dashboard de monitorización en AWS para las EC2 existentes.
+
+Objetivos de la configuración:
+- Configurar la integración de Datadog con AWS usando Terraform.
+- Instalar el agente Datadog en la instancia EC2.
+- Crear un dashboard en Datadog para visualizar métricas clave de AWS.
+
+Utiliza la estructura que ya está configurada de terraform, como base, y extiende la configuración con los nuevos requerimientos solicitados
+explícame que estas haciendo en cada paso de la configuración
 ```
 
-Este prompt me ayudó a entender cómo configurar la integración entre Datadog y AWS utilizando Terraform, incluyendo la creación de políticas IAM necesarias y la configuración del agente Datadog.
-
 ```
-¿Qué permisos necesita Datadog para monitorear mis recursos AWS?
+i have these errors with the new configuration, some duplicate variable declarations. fix the errors
 ```
-
-Este prompt me permitió identificar los permisos específicos que Datadog necesita para acceder a métricas de CloudWatch, logs y otros recursos de AWS.
-
-### Configuración de Dashboards
-
-```
-¿Cómo puedo crear un dashboard en Datadog para monitorear mis instancias EC2 usando Terraform?
-```
-
-Este prompt me guió en la creación de dashboards de Datadog utilizando Terraform, incluyendo la configuración de widgets para métricas como CPU, memoria y red.
-
-```
-¿Qué métricas son importantes monitorear para aplicaciones en contenedores Docker?
-```
-
-Este prompt me ayudó a identificar las métricas clave para monitorear aplicaciones en contenedores Docker, como uso de CPU, memoria, E/S de disco y red.
-
-### Configuración de Alertas
-
-```
-¿Cómo puedo configurar alertas en Datadog para notificarme cuando el uso de CPU supere cierto umbral?
-```
-
-Este prompt me mostró cómo configurar alertas basadas en umbrales para métricas críticas como el uso de CPU.
-
-```
-¿Cuáles son las mejores prácticas para configurar alertas y evitar falsos positivos?
-```
-
-Este prompt me proporcionó información sobre las mejores prácticas para configurar alertas efectivas, incluyendo la configuración de umbrales adecuados y períodos de evaluación.
-
-### Pruebas de Monitoreo
-
-```
-¿Cómo puedo probar que mis alertas de Datadog funcionan correctamente?
-```
-
-Este prompt me ayudó a entender cómo probar las alertas configuradas para asegurarme de que funcionan como se espera.
-
-```
-¿Cómo puedo simular una carga alta en mis instancias EC2 para probar las alertas?
-```
-
-Este prompt me proporcionó métodos para generar carga artificial en instancias EC2 y probar las alertas de Datadog.
-
-### Optimización de Costos
-
-```
-¿Cómo puedo optimizar los costos de Datadog mientras mantengo un monitoreo efectivo?
-```
-
-Este prompt me ayudó a entender estrategias para optimizar los costos de Datadog, como ajustar la frecuencia de recopilación de métricas y filtrar logs innecesarios.
-
-### Troubleshooting
-
-```
-El agente de Datadog no está enviando métricas desde mis instancias EC2, ¿cómo puedo solucionar este problema?
-```
-
-Este prompt me guió en la resolución de problemas comunes con el agente de Datadog, incluyendo verificación de conectividad, permisos y configuración.
-
-## Conclusiones y Próximos Pasos
-
-La configuración de Terraform con AWS y Datadog ha sido un proceso de aprendizaje valioso que ha requerido superar varios desafíos técnicos. Los principales aprendizajes incluyen:
-
-1. **Infraestructura como código**: La importancia de gestionar la infraestructura utilizando herramientas como Terraform para garantizar la reproducibilidad y consistencia.
-
-2. **Monitoreo proactivo**: La configuración de Datadog nos permite detectar problemas antes de que afecten a los usuarios finales.
-
-3. **Seguridad**: La implementación de prácticas seguras para el manejo de credenciales y secretos es fundamental.
-
-4. **Documentación**: Documentar los procesos, desafíos y soluciones facilita el mantenimiento futuro y la transferencia de conocimiento.
-
-### Próximos Pasos
-
-1. Implementar monitoreo más detallado a nivel de aplicación
-2. Configurar alertas adicionales para otros componentes críticos
-3. Explorar funcionalidades avanzadas de Datadog como APM (Application Performance Monitoring)
-4. Automatizar más aspectos de la configuración de monitoreo

--- a/tf/README-monitoring-JLSO.md
+++ b/tf/README-monitoring-JLSO.md
@@ -1,0 +1,119 @@
+# Configuración de Monitorización con Datadog para AWS EC2
+
+Este proyecto configura la monitorización de instancias EC2 en AWS utilizando Datadog a través de Terraform.
+
+## Estructura del Proyecto
+
+- `main.tf`: Configuración principal de Terraform y proveedores
+- `ec2.tf`: Definición de instancias EC2
+- `s3.tf`: Configuración del bucket S3 y objetos
+- `security_groups.tf`: Definición de grupos de seguridad
+- `iam.tf`: Configuración de roles y políticas IAM
+- `monitors.tf`: Definición de monitores y alertas de Datadog
+- `variables.tf`: Definición de variables para la configuración
+- `scripts/`: Scripts de inicialización para instancias EC2
+
+## Componentes de Monitorización
+
+### 1. Integración de Datadog con AWS
+
+Se ha configurado una política IAM que permite a Datadog acceder a métricas de CloudWatch y otros recursos de AWS. Esta política incluye permisos para:
+
+- Acceso a métricas de CloudWatch
+- Descripción de instancias EC2
+- Acceso a logs
+- Acceso a CloudTrail
+- Acceso a AWS Health
+
+### 2. Agente Datadog en Instancias EC2
+
+El agente Datadog se instala automáticamente en las instancias EC2 a través de scripts de inicialización. La configuración incluye:
+
+- Recopilación de métricas del sistema (CPU, memoria, disco, red)
+- Recopilación de logs
+- Monitorización de procesos
+- Integración con Docker
+- Recopilación de etiquetas EC2
+
+### 3. Dashboard de Datadog
+
+Se ha creado un dashboard completo en Datadog que incluye:
+
+- Métricas de CPU (utilización, créditos)
+- Métricas de memoria
+- Métricas de red (tráfico entrante/saliente, paquetes)
+- Métricas de disco (lectura/escritura, uso)
+- Lista de las instancias con mayor uso de CPU
+
+### 4. Monitores y Alertas
+
+Se han configurado varios monitores para alertar sobre problemas potenciales:
+
+- Alta utilización de CPU (>80%)
+- Alta utilización de memoria (>85%)
+- Alto uso de disco (>85%)
+- Instancias EC2 no disponibles
+- Errores en logs de aplicación
+
+## Requisitos
+
+- Terraform >= 0.14
+- Cuenta de AWS con permisos adecuados
+- Cuenta de Datadog con API key y Application key
+
+## Uso
+
+1. Configura las variables de entorno o crea un archivo `.env` con las siguientes variables:
+
+   ```
+   TF_VAR_datadog_api_key=<tu_api_key>
+   TF_VAR_datadog_app_key=<tu_app_key>
+   ```
+
+2. Inicializa Terraform:
+
+   ```
+   terraform init
+   ```
+
+3. Planifica los cambios:
+
+   ```
+   terraform plan
+   ```
+
+4. Aplica la configuración:
+   ```
+   terraform apply
+   ```
+
+## Personalización
+
+Puedes personalizar la configuración modificando las variables en `variables.tf` o proporcionando valores diferentes al ejecutar `terraform apply`:
+
+```
+terraform apply -var="environment=staging" -var="team=devops"
+```
+
+## Consideraciones de Seguridad
+
+- Las claves API de Datadog se manejan como variables sensibles
+- Se recomienda utilizar AWS Secrets Manager o Parameter Store para almacenar secretos en producción
+- Los scripts de inicialización obtienen las credenciales de forma segura desde un archivo `.env` almacenado en S3
+
+## Mantenimiento
+
+Para actualizar la configuración:
+
+1. Modifica los archivos de Terraform según sea necesario
+2. Ejecuta `terraform plan` para verificar los cambios
+3. Ejecuta `terraform apply` para aplicar los cambios
+
+## Troubleshooting
+
+Si el agente Datadog no está enviando métricas:
+
+1. Verifica que las instancias EC2 tengan acceso a Internet
+2. Comprueba los logs del agente: `/var/log/datadog/agent.log`
+3. Asegúrate de que la política IAM tenga los permisos correctos
+4. Verifica que las claves API sean válidas

--- a/tf/ec2.tf
+++ b/tf/ec2.tf
@@ -13,15 +13,26 @@ data "aws_ami" "amazon_linux" {
   }
 }
 
+# Calcular hash de los scripts para forzar la recreación cuando cambien
+locals {
+  backend_user_data_hash = md5(file("scripts/backend_user_data.sh"))
+  frontend_user_data_hash = md5(file("scripts/frontend_user_data.sh"))
+}
+
 resource "aws_instance" "backend" {
   ami                    = data.aws_ami.amazon_linux.id
   instance_type          = "t2.micro"
   iam_instance_profile   = aws_iam_instance_profile.ec2_instance_profile.name
   user_data              = templatefile("scripts/backend_user_data.sh", { timestamp = timestamp() })
   vpc_security_group_ids = [aws_security_group.backend_sg.id]
+  
+  # Forzar recreación cuando cambia el script
+  user_data_replace_on_change = true
+  
   tags = {
     Name = "lti-project-backend"
-    Datadog     = "true"
+    Datadog = "true"
+    ScriptHash = local.backend_user_data_hash
   }
 }
 
@@ -31,9 +42,14 @@ resource "aws_instance" "frontend" {
   iam_instance_profile   = aws_iam_instance_profile.ec2_instance_profile.name
   user_data              = templatefile("scripts/frontend_user_data.sh", { timestamp = timestamp() })
   vpc_security_group_ids = [aws_security_group.frontend_sg.id]
+  
+  # Forzar recreación cuando cambia el script
+  user_data_replace_on_change = true
+  
   tags = {
     Name = "lti-project-frontend"
-    Datadog     = "true"
+    Datadog = "true"
+    ScriptHash = local.frontend_user_data_hash
   }
 }
 
@@ -43,4 +59,12 @@ output "backend_instance_id" {
 
 output "frontend_instance_id" {
   value = aws_instance.frontend.id
+}
+
+output "backend_public_ip" {
+  value = aws_instance.backend.public_ip
+}
+
+output "frontend_public_ip" {
+  value = aws_instance.frontend.public_ip
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -17,7 +17,7 @@ provider "datadog" {
   api_key = var.datadog_api_key
   app_key = var.datadog_app_key
   # Configura la región de Datadog
-  api_url = "https://api.us5.datadoghq.com"
+  api_url = "https://api.datadoghq.com"
 }
 
 # Variables de entorno para las claves de Datadog
@@ -33,14 +33,14 @@ variable "datadog_app_key" {
 
 # Política de IAM para permitir a Datadog acceder a CloudWatch
 resource "aws_iam_policy" "datadog_policy" {
-  name        = "DatadogPolicy"
+  name        = "DatadogPolicy-jlso"
   description = "Política para permitir a Datadog acceder a CloudWatch"
-  policy      = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "cloudwatch:GetMetricData",
           "cloudwatch:ListMetrics",
           "ec2:DescribeInstances",
@@ -52,7 +52,7 @@ resource "aws_iam_policy" "datadog_policy" {
           "tag:GetTagKeys",
           "tag:GetTagValues"
         ],
-        "Resource": "*"
+        "Resource" : "*"
       }
     ]
   })

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -16,20 +16,25 @@ provider "aws" {
 provider "datadog" {
   api_key = var.datadog_api_key
   app_key = var.datadog_app_key
-  # Configura la región de Datadog
-  api_url = "https://api.datadoghq.com"
+  api_url = var.datadog_api_url
 }
 
 # Variables de entorno para las claves de Datadog
-variable "datadog_api_key" {
-  description = "API Key para Datadog"
-  type        = string
-}
-
-variable "datadog_app_key" {
-  description = "App Key para Datadog"
-  type        = string
-}
+// Removing duplicate variable declarations as they are defined in variables.tf
+// variable "datadog_api_key" {
+//   description = "API Key para Datadog"
+//   type        = string
+// }
+// 
+// variable "datadog_app_key" {
+//   description = "App Key para Datadog"
+//   type        = string
+// }
+// 
+// variable "datadog_api_url" {
+//   description = "API URL for Datadog"
+//   type        = string
+// }
 
 # Política de IAM para permitir a Datadog acceder a CloudWatch
 resource "aws_iam_policy" "datadog_policy" {
@@ -43,14 +48,24 @@ resource "aws_iam_policy" "datadog_policy" {
         "Action" : [
           "cloudwatch:GetMetricData",
           "cloudwatch:ListMetrics",
+          "cloudwatch:GetMetricStatistics",
           "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ec2:DescribeTags",
+          "ec2:DescribeVolumes",
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams",
           "logs:GetLogEvents",
           "logs:FilterLogEvents",
           "tag:GetResources",
           "tag:GetTagKeys",
-          "tag:GetTagValues"
+          "tag:GetTagValues",
+          "cloudtrail:LookupEvents",
+          "cloudtrail:GetTrailStatus",
+          "cloudtrail:DescribeTrails",
+          "health:DescribeEvents",
+          "health:DescribeEventDetails",
+          "health:DescribeAffectedEntities"
         ],
         "Resource" : "*"
       }
@@ -68,34 +83,183 @@ data "aws_instances" "all" {
 
 # Crear un dashboard en Datadog
 resource "datadog_dashboard" "ec2_dashboard" {
-  title       = "EC2 Monitoring Dashboard"
-  description = "Dashboard para monitorizar instancias EC2"
+  title       = "EC2 Monitoring Dashboard - JLSO"
+  description = "Dashboard para monitorizar instancias EC2 - Creado por JLSO"
   layout_type = "ordered"
 
   widget {
-    timeseries_definition {
-      title = "CPU Utilization"
-      request {
-        q = "avg:aws.ec2.cpuutilization{*} by {instance_id}"
+    group_definition {
+      title = "CPU Metrics"
+      layout_type = "ordered"
+      widget {
+        timeseries_definition {
+          title = "CPU Utilization"
+          request {
+            q = "avg:aws.ec2.cpuutilization{*} by {instance_id}"
+            display_type = "line"
+          }
+          yaxis {
+            max = "100"
+            min = "0"
+            scale = "linear"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "CPU Credit Usage"
+          request {
+            q = "avg:aws.ec2.cpucredit_usage{*} by {instance_id}"
+            display_type = "line"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "CPU Credit Balance"
+          request {
+            q = "avg:aws.ec2.cpucredit_balance{*} by {instance_id}"
+            display_type = "line"
+          }
+        }
       }
     }
   }
 
   widget {
-    timeseries_definition {
-      title = "Network In"
-      request {
-        q = "avg:aws.ec2.network_in{*} by {instance_id}"
+    group_definition {
+      title = "Memory Metrics"
+      layout_type = "ordered"
+      widget {
+        timeseries_definition {
+          title = "Memory Used"
+          request {
+            q = "avg:system.mem.used{*} by {host}"
+            display_type = "line"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "Memory Free"
+          request {
+            q = "avg:system.mem.free{*} by {host}"
+            display_type = "line"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "Memory Usage (%)"
+          request {
+            q = "avg:system.mem.used{*} by {host} / avg:system.mem.total{*} by {host} * 100"
+            display_type = "line"
+          }
+          yaxis {
+            max = "100"
+            min = "0"
+            scale = "linear"
+          }
+        }
       }
     }
   }
 
   widget {
-    timeseries_definition {
-      title = "Network Out"
-      request {
-        q = "avg:aws.ec2.network_out{*} by {instance_id}"
+    group_definition {
+      title = "Network Metrics"
+      layout_type = "ordered"
+      widget {
+        timeseries_definition {
+          title = "Network In"
+          request {
+            q = "avg:aws.ec2.network_in{*} by {instance_id}"
+            display_type = "area"
+          }
+        }
       }
+      widget {
+        timeseries_definition {
+          title = "Network Out"
+          request {
+            q = "avg:aws.ec2.network_out{*} by {instance_id}"
+            display_type = "area"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "Network Packets In/Out"
+          request {
+            q = "avg:aws.ec2.network_packets_in{*} by {instance_id}"
+            display_type = "line"
+          }
+          request {
+            q = "avg:aws.ec2.network_packets_out{*} by {instance_id}"
+            display_type = "line"
+          }
+        }
+      }
+    }
+  }
+
+  widget {
+    group_definition {
+      title = "Disk Metrics"
+      layout_type = "ordered"
+      widget {
+        timeseries_definition {
+          title = "Disk Read Bytes"
+          request {
+            q = "avg:aws.ec2.disk_read_bytes{*} by {instance_id}"
+            display_type = "area"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "Disk Write Bytes"
+          request {
+            q = "avg:aws.ec2.disk_write_bytes{*} by {instance_id}"
+            display_type = "area"
+          }
+        }
+      }
+      widget {
+        timeseries_definition {
+          title = "Disk Usage (%)"
+          request {
+            q = "avg:system.disk.in_use{*} by {host,device} * 100"
+            display_type = "line"
+          }
+          yaxis {
+            max = "100"
+            min = "0"
+            scale = "linear"
+          }
+        }
+      }
+    }
+  }
+
+  widget {
+    toplist_definition {
+      title = "Top Instances by CPU Usage"
+      request {
+        q = "top(avg:aws.ec2.cpuutilization{*} by {instance_id}, 10, 'mean', 'desc')"
+      }
+    }
+  }
+
+  widget {
+    note_definition {
+      content = "Dashboard creado con Terraform para monitorizar instancias EC2 en AWS. Última actualización: ${formatdate("DD-MM-YYYY", timestamp())}"
+      background_color = "gray"
+      font_size = "14"
+      text_align = "center"
+      show_tick = true
+      tick_pos = "bottom"
+      tick_edge = "bottom"
     }
   }
 }

--- a/tf/monitors.tf
+++ b/tf/monitors.tf
@@ -1,0 +1,125 @@
+# Monitores de Datadog para alertas
+
+# Monitor para CPU alto en instancias EC2
+resource "datadog_monitor" "high_cpu" {
+  name               = "Alta utilización de CPU en instancias EC2 - JLSO"
+  type               = "metric alert"
+  message            = <<EOT
+La utilización de CPU está por encima del 80% durante más de 5 minutos.
+
+@slack-${var.notification_slack}
+@email-${var.notification_email}
+EOT
+  query              = "avg(last_5m):avg:aws.ec2.cpuutilization{*} by {instance_id} > 80"
+  monitor_thresholds {
+    critical = 80
+    warning  = 70
+  }
+  notify_no_data    = false
+  require_full_window = false
+  include_tags      = true
+  evaluation_delay  = 60
+  new_group_delay   = 300
+  renotify_interval = 60
+  
+  tags = ["service:ec2", "team:${var.team}", "env:${var.environment}", "application:${var.application}", "managed-by:terraform"]
+}
+
+# Monitor para memoria alta en instancias EC2
+resource "datadog_monitor" "high_memory" {
+  name               = "Alta utilización de memoria en instancias EC2 - JLSO"
+  type               = "metric alert"
+  message            = <<EOT
+La utilización de memoria está por encima del 85% durante más de 5 minutos.
+
+@slack-${var.notification_slack}
+@email-${var.notification_email}
+EOT
+  query              = "avg(last_5m):avg:system.mem.used{*} by {host} / avg:system.mem.total{*} by {host} * 100 > 85"
+  monitor_thresholds {
+    critical = 85
+    warning  = 75
+  }
+  notify_no_data    = false
+  require_full_window = false
+  include_tags      = true
+  evaluation_delay  = 60
+  new_group_delay   = 300
+  renotify_interval = 60
+  
+  tags = ["service:ec2", "team:${var.team}", "env:${var.environment}", "application:${var.application}", "managed-by:terraform"]
+}
+
+# Monitor para espacio en disco alto en instancias EC2
+resource "datadog_monitor" "high_disk" {
+  name               = "Alto uso de disco en instancias EC2 - JLSO"
+  type               = "metric alert"
+  message            = <<EOT
+El uso de disco está por encima del 85% durante más de 10 minutos.
+
+@slack-${var.notification_slack}
+@email-${var.notification_email}
+EOT
+  query              = "avg(last_10m):avg:system.disk.in_use{*} by {host,device} * 100 > 85"
+  monitor_thresholds {
+    critical = 85
+    warning  = 75
+  }
+  notify_no_data    = false
+  require_full_window = false
+  include_tags      = true
+  evaluation_delay  = 60
+  new_group_delay   = 300
+  renotify_interval = 60
+  
+  tags = ["service:ec2", "team:${var.team}", "env:${var.environment}", "application:${var.application}", "managed-by:terraform"]
+}
+
+# Monitor para instancias EC2 no disponibles
+resource "datadog_monitor" "ec2_status_check" {
+  name               = "Instancia EC2 no disponible - JLSO"
+  type               = "metric alert"
+  message            = <<EOT
+La instancia EC2 no está pasando los status checks durante más de 5 minutos.
+
+@slack-${var.notification_slack}
+@email-${var.notification_email}
+EOT
+  query              = "min(last_5m):avg:aws.ec2.status_check_failed{*} by {instance_id} > 0"
+  monitor_thresholds {
+    critical = 0
+  }
+  notify_no_data    = true
+  no_data_timeframe = 10
+  require_full_window = false
+  include_tags      = true
+  evaluation_delay  = 60
+  new_group_delay   = 300
+  renotify_interval = 30
+  
+  tags = ["service:ec2", "team:${var.team}", "env:${var.environment}", "application:${var.application}", "managed-by:terraform"]
+}
+
+# Monitor para errores en logs de aplicación - Comentado temporalmente debido a problemas de validación
+/*
+resource "datadog_monitor" "application_errors" {
+  name               = "Errores en logs de aplicación - JLSO"
+  type               = "log alert"
+  message            = <<EOT
+Se han detectado muchos errores en los logs de la aplicación.
+
+@slack-${var.notification_slack}
+@email-${var.notification_email}
+EOT
+  query              = "logs(\"status:error OR level:error\").index(\"*\").count() > 10"
+  monitor_thresholds {
+    critical = 10
+    warning  = 5
+  }
+  notify_no_data    = false
+  require_full_window = false
+  include_tags      = true
+  
+  tags = ["service:application", "team:${var.team}", "env:${var.environment}", "application:${var.application}", "managed-by:terraform"]
+}
+*/ 

--- a/tf/s3.tf
+++ b/tf/s3.tf
@@ -1,6 +1,12 @@
 resource "aws_s3_bucket" "code_bucket" {
-  bucket = "lti-project-code-bucket"
-  acl    = "private"
+  bucket = "lti-project-code-bucket-jlso"
+}
+
+resource "aws_s3_bucket_ownership_controls" "code_bucket_ownership" {
+  bucket = aws_s3_bucket.code_bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "null_resource" "generate_zip" {
@@ -13,16 +19,16 @@ resource "null_resource" "generate_zip" {
   }
 }
 
-resource "aws_s3_bucket_object" "backend_zip" {
+resource "aws_s3_object" "backend_zip" {
   bucket     = aws_s3_bucket.code_bucket.bucket
   key        = "backend.zip"
   source     = "../backend.zip"
-  depends_on = [null_resource.generate_zip]
+  depends_on = [null_resource.generate_zip, aws_s3_bucket.code_bucket, aws_s3_bucket_ownership_controls.code_bucket_ownership]
 }
 
-resource "aws_s3_bucket_object" "frontend_zip" {
+resource "aws_s3_object" "frontend_zip" {
   bucket     = aws_s3_bucket.code_bucket.bucket
   key        = "frontend.zip"
   source     = "../frontend.zip"
-  depends_on = [null_resource.generate_zip]
+  depends_on = [null_resource.generate_zip, aws_s3_bucket.code_bucket, aws_s3_bucket_ownership_controls.code_bucket_ownership]
 }

--- a/tf/scripts/backend_user_data.sh
+++ b/tf/scripts/backend_user_data.sh
@@ -10,7 +10,7 @@ yum install -y docker
 service docker start
 
 # Descargar y descomprimir el archivo backend.zip desde S3
-aws s3 cp s3://lti-project-code-bucket/backend.zip /home/ec2-user/backend.zip
+aws s3 cp s3://lti-project-code-bucket-jlso/backend.zip /home/ec2-user/backend.zip
 unzip /home/ec2-user/backend.zip -d /home/ec2-user/
 
 # Construir la imagen Docker para el backend

--- a/tf/scripts/backend_user_data.sh
+++ b/tf/scripts/backend_user_data.sh
@@ -1,24 +1,331 @@
 #!/bin/bash
-export DD_AGENT_MAJOR_VERSION=7 
-export DD_API_KEY='76cd5e07d41cec7b205a01ffbc26c5ae'
-export DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
+# Configurar registro detallado para depuración
+set -x
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+echo "Iniciando script de configuración del backend: $(date)"
+
+# Instalar dependencias necesarias
+echo "Instalando dependencias..."
 yum update -y
-yum install -y docker
+# Usar comillas simples para evitar que Terraform interprete las variables
+yum install -y docker unzip awscli || echo "Instalación básica completada"
+echo "Intentando instalar headers del kernel..."
+yum install -y kernel-devel kernel-headers || echo "No se pudieron instalar los headers del kernel"
 
-# Iniciar el servicio de Docker
-service docker start
+# Configurar br_netfilter para Docker
+echo "Configurando br_netfilter para Docker..."
+modprobe br_netfilter || echo "No se pudo cargar br_netfilter"
+echo 'net.bridge.bridge-nf-call-iptables=1' | tee -a /etc/sysctl.conf
+sysctl -p
+
+# Asegurarse de que Docker esté instalado correctamente
+if ! command -v docker &> /dev/null; then
+    echo "Docker no se instaló correctamente. Intentando instalar manualmente..."
+    amazon-linux-extras install docker -y
+    if ! command -v docker &> /dev/null; then
+        echo "ERROR: No se pudo instalar Docker. Abortando."
+        exit 1
+    fi
+fi
+
+# Descargar el archivo .env desde S3
+echo "Descargando archivo .env desde S3..."
+aws s3 cp s3://lti-project-code-bucket-jlso/.env /home/ec2-user/.env || echo "No se pudo descargar el archivo .env"
+
+# Cargar variables desde el archivo .env
+if [ -f /home/ec2-user/.env ]; then
+  export $(grep -v '^#' /home/ec2-user/.env | xargs)
+  echo "Variables de entorno cargadas desde .env"
+else
+  echo "Archivo .env no encontrado, usando valores por defecto"
+  # Valores por defecto en caso de que no se encuentre el archivo .env
+  export DD_AGENT_MAJOR_VERSION=7
+  export DD_API_KEY="<YOUR-API-KEY>"
+  export DD_SITE="datadoghq.com"
+fi
+
+# Configuración avanzada del agente Datadog
+echo "Configurando agente Datadog..."
+export DD_AGENT_MAJOR_VERSION=7
+export DD_API_KEY="<YOUR-API-KEY>"
+export DD_SITE="datadoghq.com"
+export DD_HOSTNAME="backend-$(hostname)"
+export DD_TAGS="service:backend,environment:production,team:sre,application:lti-project"
+export DD_APM_ENABLED=true
+export DD_LOGS_ENABLED=true
+export DD_PROCESS_AGENT_ENABLED=true
+export DD_DOCKER_ENABLED=true
+export DD_COLLECT_EC2_TAGS=true
+
+# Instalar el agente Datadog
+echo "Instalando agente Datadog..."
+DD_API_KEY="<YOUR-API-KEY>" DD_SITE="datadoghq.com" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)" || {
+  echo "Error al instalar el agente Datadog. Reintentando..."
+  DD_API_KEY="<YOUR-API-KEY>" DD_SITE="datadoghq.com" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+}
+
+# Verificar que el agente se instaló correctamente
+if ! command -v datadog-agent &> /dev/null; then
+  echo "ERROR: No se pudo instalar el agente Datadog"
+else
+  echo "Agente Datadog instalado correctamente"
+fi
+
+# Asegurarse de que el directorio de configuración existe
+mkdir -p /etc/datadog-agent/
+
+# Crear archivo datadog.yaml básico si no existe
+if [ ! -f /etc/datadog-agent/datadog.yaml ]; then
+  echo "Creando archivo datadog.yaml básico..."
+  HOSTNAME=$(hostname)
+  cat > /etc/datadog-agent/datadog.yaml << EOF
+api_key: "<YOUR-API-KEY>"
+site: "datadoghq.com"
+hostname: "backend-$HOSTNAME"
+tags:
+  - service:backend
+  - environment:production
+  - team:sre
+  - application:lti-project
+logs_enabled: true
+apm_config:
+  enabled: true
+process_config:
+  enabled: true
+collect_ec2_tags: true
+
+# System probe configuration
+system_probe_config:
+  enabled: true
+EOF
+fi
+
+# Configurar System Probe
+echo "Configurando System Probe..."
+cat > /etc/datadog-agent/system-probe.yaml << EOF
+system_probe_config:
+  enabled: true
+  sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
+
+network_config:
+  enabled: true
+EOF
+
+# Configurar check de CPU
+echo "Configurando check de CPU..."
+mkdir -p /etc/datadog-agent/conf.d/cpu.d/
+cat > /etc/datadog-agent/conf.d/cpu.d/conf.yaml << EOF
+init_config:
+
+instances:
+  - {}
+EOF
+
+# Configurar check de System Core
+echo "Configurando check de System Core..."
+mkdir -p /etc/datadog-agent/conf.d/system_core.d/
+cat > /etc/datadog-agent/conf.d/system_core.d/conf.yaml << EOF
+init_config:
+
+instances:
+  - {}
+EOF
+
+# Configurar integraciones de Datadog
+echo "Configurando integración de Docker para Datadog..."
+mkdir -p /etc/datadog-agent/conf.d/docker.d/
+cat > /etc/datadog-agent/conf.d/docker.d/conf.yaml << EOF
+init_config:
+
+instances:
+  - url: "unix://var/run/docker.sock"
+    collect_container_size: true
+    collect_container_count: true
+    collect_volume_count: true
+    collect_images_stats: true
+    collect_exit_codes: true
+    tags:
+      - "service:backend"
+EOF
+
+# Corregir permisos
+echo "Corrigiendo permisos de los archivos de configuración..."
+chown -R dd-agent:dd-agent /etc/datadog-agent/
+chmod -R 755 /etc/datadog-agent/
+
+# Reiniciar el agente para aplicar la configuración
+echo "Reiniciando agente Datadog..."
+systemctl restart datadog-agent
+systemctl enable datadog-agent
+
+# Iniciar y habilitar System Probe
+echo "Iniciando System Probe..."
+systemctl restart datadog-agent-sysprobe || systemctl start datadog-agent-sysprobe
+systemctl enable datadog-agent-sysprobe || echo "No se pudo habilitar datadog-agent-sysprobe"
+
+# Iniciar y habilitar Process Agent
+echo "Iniciando Process Agent..."
+systemctl restart datadog-agent-process || systemctl start datadog-agent-process
+systemctl enable datadog-agent-process || echo "No se pudo habilitar datadog-agent-process"
+
+# Verificar que el agente Datadog se inició correctamente
+echo "Verificando que el agente Datadog se inició correctamente..."
+for i in {1..5}; do
+  if systemctl is-active datadog-agent >/dev/null 2>&1; then
+    echo "Agente Datadog se ha iniciado correctamente"
+    break
+  else
+    echo "Esperando a que el agente Datadog se inicie (intento $i/5)..."
+    sleep 10
+    systemctl restart datadog-agent
+  fi
+  
+  if [ $i -eq 5 ]; then
+    echo "ADVERTENCIA: No se pudo iniciar el agente Datadog después de 5 intentos"
+    systemctl status datadog-agent
+    # No salimos con error para permitir que el resto del script continúe
+  fi
+done
+
+# Iniciar y habilitar el servicio de Docker
+echo "Iniciando el servicio Docker..."
+systemctl start docker
+systemctl enable docker
+
+# Verificar que Docker esté en funcionamiento
+echo "Verificando que Docker esté en funcionamiento..."
+for i in {1..5}; do
+  if systemctl is-active docker >/dev/null 2>&1; then
+    echo "Docker se ha iniciado correctamente"
+    break
+  else
+    echo "Esperando a que Docker se inicie (intento $i/5)..."
+    sleep 10
+    systemctl start docker
+  fi
+  
+  if [ $i -eq 5 ]; then
+    echo "ERROR: No se pudo iniciar Docker después de 5 intentos"
+    systemctl status docker
+    exit 1
+  fi
+done
+
+# Asegurarse de que el usuario ec2-user pueda usar Docker sin sudo
+echo "Configurando permisos de Docker para ec2-user..."
+usermod -aG docker ec2-user
+# Reiniciar Docker para aplicar los cambios de grupo
+systemctl restart docker
+sleep 5
 
 # Descargar y descomprimir el archivo backend.zip desde S3
-aws s3 cp s3://lti-project-code-bucket-jlso/backend.zip /home/ec2-user/backend.zip
-unzip /home/ec2-user/backend.zip -d /home/ec2-user/
+echo "Descargando y descomprimiendo el código del backend..."
+aws s3 cp s3://lti-project-code-bucket-jlso/backend.zip /home/ec2-user/backend.zip || {
+    echo "ERROR: No se pudo descargar backend.zip desde S3"
+    exit 1
+}
+unzip -o /home/ec2-user/backend.zip -d /home/ec2-user/ || {
+    echo "ERROR: No se pudo descomprimir backend.zip"
+    exit 1
+}
+
+# Verificar que el directorio del backend existe
+if [ ! -d "/home/ec2-user/backend" ]; then
+    echo "ERROR: No se encontró el directorio /home/ec2-user/backend después de descomprimir"
+    ls -la /home/ec2-user/
+    exit 1
+fi
 
 # Construir la imagen Docker para el backend
+echo "Construyendo imagen Docker para el backend..."
 cd /home/ec2-user/backend
-docker build -t lti-backend .
+docker build -t lti-backend . || {
+    echo "ERROR: Falló la construcción de la imagen Docker"
+    exit 1
+}
 
-# Ejecutar el contenedor Docker
-docker run -d -p 8080:8080 lti-backend
+# Verificar si ya existe un contenedor con el mismo nombre
+echo "Verificando si ya existe un contenedor lti-backend..."
+if docker ps -a | grep lti-backend; then
+    echo "Eliminando contenedor existente lti-backend..."
+    docker stop lti-backend || true
+    docker rm lti-backend || true
+fi
+
+# Ejecutar el contenedor Docker con etiquetas para Datadog
+echo "Iniciando contenedor Docker para el backend..."
+INSTANCE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+docker run -d -p 8080:8080 \
+  --name lti-backend \
+  -e DD_AGENT_HOST=$INSTANCE_IP \
+  -e DD_ENV=production \
+  -e DD_SERVICE=backend \
+  -e DD_VERSION=1.0 \
+  lti-backend
+
+# Verificar que el contenedor se haya iniciado correctamente
+echo "Verificando que el contenedor se haya iniciado correctamente..."
+sleep 10  # Aumentamos el tiempo de espera para dar más tiempo al contenedor para iniciar
+MAX_RETRIES=3
+for i in $(seq 1 $MAX_RETRIES); do
+  if docker ps | grep lti-backend; then
+    echo "Contenedor lti-backend iniciado correctamente"
+    # Verificar que el servicio responde
+    echo "Verificando que el servicio responde..."
+    sleep 5
+    if curl -s http://localhost:8080 > /dev/null; then
+      echo "El servicio backend responde correctamente"
+      break
+    else
+      echo "El servicio no responde en el puerto 8080, pero el contenedor está en ejecución"
+      if [ $i -eq $MAX_RETRIES ]; then
+        echo "ADVERTENCIA: El servicio no responde después de $MAX_RETRIES intentos"
+        docker logs lti-backend
+      else
+        echo "Reintentando en 10 segundos... (intento $i/$MAX_RETRIES)"
+        sleep 10
+      fi
+    fi
+  else
+    echo "ERROR: No se pudo iniciar el contenedor lti-backend (intento $i/$MAX_RETRIES)"
+    docker logs lti-backend
+    echo "Estado de Docker:"
+    systemctl status docker
+    echo "Imágenes disponibles:"
+    docker images
+    echo "Todos los contenedores:"
+    docker ps -a
+    
+    if [ $i -eq $MAX_RETRIES ]; then
+      echo "ERROR: No se pudo iniciar el contenedor después de $MAX_RETRIES intentos"
+    else
+      echo "Reintentando iniciar el contenedor... (intento $i/$MAX_RETRIES)"
+      docker run -d -p 8080:8080 \
+        --name lti-backend \
+        -e DD_AGENT_HOST=$INSTANCE_IP \
+        -e DD_ENV=production \
+        -e DD_SERVICE=backend \
+        -e DD_VERSION=1.0 \
+        lti-backend
+      sleep 10
+    fi
+  fi
+done
+
+# Verificar la integración con Datadog
+echo "Verificando integración con Datadog..."
+if systemctl is-active datadog-agent >/dev/null 2>&1; then
+  echo "Agente Datadog está activo, verificando estado..."
+  datadog-agent status || echo "No se pudo obtener el estado del agente Datadog"
+  
+  # Verificar integración con Docker
+  echo "Verificando integración de Datadog con Docker..."
+  datadog-agent status | grep -A 10 docker || echo "No se encontró información sobre la integración con Docker"
+else
+  echo "ADVERTENCIA: El agente Datadog no está activo"
+fi
 
 # Timestamp to force update
+echo "Configuración completada: $(date)"
 echo "Timestamp: ${timestamp}"

--- a/tf/scripts/frontend_user_data.sh
+++ b/tf/scripts/frontend_user_data.sh
@@ -1,23 +1,331 @@
 #!/bin/bash
-yum update -y
-yum install -y docker
-export DD_AGENT_MAJOR_VERSION=7 
-export DD_API_KEY='76cd5e07d41cec7b205a01ffbc26c5ae'
-export DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
-# Iniciar el servicio de Docker
-service docker start
+# Configurar registro detallado para depuración
+set -x
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+echo "Iniciando script de configuración del frontend: $(date)"
+
+# Instalar dependencias necesarias
+echo "Instalando dependencias..."
+yum update -y
+# Usar comillas simples para evitar que Terraform interprete las variables
+yum install -y docker unzip awscli || echo "Instalación básica completada"
+echo "Intentando instalar headers del kernel..."
+yum install -y kernel-devel kernel-headers || echo "No se pudieron instalar los headers del kernel"
+
+# Configurar br_netfilter para Docker
+echo "Configurando br_netfilter para Docker..."
+modprobe br_netfilter || echo "No se pudo cargar br_netfilter"
+echo 'net.bridge.bridge-nf-call-iptables=1' | tee -a /etc/sysctl.conf
+sysctl -p
+
+# Asegurarse de que Docker esté instalado correctamente
+if ! command -v docker &> /dev/null; then
+    echo "Docker no se instaló correctamente. Intentando instalar manualmente..."
+    amazon-linux-extras install docker -y
+    if ! command -v docker &> /dev/null; then
+        echo "ERROR: No se pudo instalar Docker. Abortando."
+        exit 1
+    fi
+fi
+
+# Descargar el archivo .env desde S3
+echo "Descargando archivo .env desde S3..."
+aws s3 cp s3://lti-project-code-bucket-jlso/.env /home/ec2-user/.env || echo "No se pudo descargar el archivo .env"
+
+# Cargar variables desde el archivo .env
+if [ -f /home/ec2-user/.env ]; then
+  export $(grep -v '^#' /home/ec2-user/.env | xargs)
+  echo "Variables de entorno cargadas desde .env"
+else
+  echo "Archivo .env no encontrado, usando valores por defecto"
+  # Valores por defecto en caso de que no se encuentre el archivo .env
+  export DD_AGENT_MAJOR_VERSION=7
+  export DD_API_KEY="<YOUR-API-KEY>"
+  export DD_SITE="datadoghq.com"
+fi
+
+# Configuración avanzada del agente Datadog
+echo "Configurando agente Datadog..."
+export DD_AGENT_MAJOR_VERSION=7
+export DD_API_KEY="<YOUR-API-KEY>"
+export DD_SITE="datadoghq.com"
+export DD_HOSTNAME="frontend-$(hostname)"
+export DD_TAGS="service:frontend,environment:production,team:sre,application:lti-project"
+export DD_APM_ENABLED=true
+export DD_LOGS_ENABLED=true
+export DD_PROCESS_AGENT_ENABLED=true
+export DD_DOCKER_ENABLED=true
+export DD_COLLECT_EC2_TAGS=true
+
+# Instalar el agente Datadog
+echo "Instalando agente Datadog..."
+DD_API_KEY="<YOUR-API-KEY>" DD_SITE="datadoghq.com" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)" || {
+  echo "Error al instalar el agente Datadog. Reintentando..."
+  DD_API_KEY="<YOUR-API-KEY>" DD_SITE="datadoghq.com" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+}
+
+# Verificar que el agente se instaló correctamente
+if ! command -v datadog-agent &> /dev/null; then
+  echo "ERROR: No se pudo instalar el agente Datadog"
+else
+  echo "Agente Datadog instalado correctamente"
+fi
+
+# Asegurarse de que el directorio de configuración existe
+mkdir -p /etc/datadog-agent/
+
+# Crear archivo datadog.yaml básico si no existe
+if [ ! -f /etc/datadog-agent/datadog.yaml ]; then
+  echo "Creando archivo datadog.yaml básico..."
+  HOSTNAME=$(hostname)
+  cat > /etc/datadog-agent/datadog.yaml << EOF
+api_key: "<YOUR-API-KEY>"
+site: "datadoghq.com"
+hostname: "frontend-$HOSTNAME"
+tags:
+  - service:frontend
+  - environment:production
+  - team:sre
+  - application:lti-project
+logs_enabled: true
+apm_config:
+  enabled: true
+process_config:
+  enabled: true
+collect_ec2_tags: true
+
+# System probe configuration
+system_probe_config:
+  enabled: true
+EOF
+fi
+
+# Configurar System Probe
+echo "Configurando System Probe..."
+cat > /etc/datadog-agent/system-probe.yaml << EOF
+system_probe_config:
+  enabled: true
+  sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
+
+network_config:
+  enabled: true
+EOF
+
+# Configurar check de CPU
+echo "Configurando check de CPU..."
+mkdir -p /etc/datadog-agent/conf.d/cpu.d/
+cat > /etc/datadog-agent/conf.d/cpu.d/conf.yaml << EOF
+init_config:
+
+instances:
+  - {}
+EOF
+
+# Configurar check de System Core
+echo "Configurando check de System Core..."
+mkdir -p /etc/datadog-agent/conf.d/system_core.d/
+cat > /etc/datadog-agent/conf.d/system_core.d/conf.yaml << EOF
+init_config:
+
+instances:
+  - {}
+EOF
+
+# Configurar integraciones de Datadog
+echo "Configurando integración de Docker para Datadog..."
+mkdir -p /etc/datadog-agent/conf.d/docker.d/
+cat > /etc/datadog-agent/conf.d/docker.d/conf.yaml << EOF
+init_config:
+
+instances:
+  - url: "unix://var/run/docker.sock"
+    collect_container_size: true
+    collect_container_count: true
+    collect_volume_count: true
+    collect_images_stats: true
+    collect_exit_codes: true
+    tags:
+      - "service:frontend"
+EOF
+
+# Corregir permisos
+echo "Corrigiendo permisos de los archivos de configuración..."
+chown -R dd-agent:dd-agent /etc/datadog-agent/
+chmod -R 755 /etc/datadog-agent/
+
+# Reiniciar el agente para aplicar la configuración
+echo "Reiniciando agente Datadog..."
+systemctl restart datadog-agent
+systemctl enable datadog-agent
+
+# Iniciar y habilitar System Probe
+echo "Iniciando System Probe..."
+systemctl restart datadog-agent-sysprobe || systemctl start datadog-agent-sysprobe
+systemctl enable datadog-agent-sysprobe || echo "No se pudo habilitar datadog-agent-sysprobe"
+
+# Iniciar y habilitar Process Agent
+echo "Iniciando Process Agent..."
+systemctl restart datadog-agent-process || systemctl start datadog-agent-process
+systemctl enable datadog-agent-process || echo "No se pudo habilitar datadog-agent-process"
+
+# Verificar que el agente Datadog se inició correctamente
+echo "Verificando que el agente Datadog se inició correctamente..."
+for i in {1..5}; do
+  if systemctl is-active datadog-agent >/dev/null 2>&1; then
+    echo "Agente Datadog se ha iniciado correctamente"
+    break
+  else
+    echo "Esperando a que el agente Datadog se inicie (intento $i/5)..."
+    sleep 10
+    systemctl restart datadog-agent
+  fi
+  
+  if [ $i -eq 5 ]; then
+    echo "ADVERTENCIA: No se pudo iniciar el agente Datadog después de 5 intentos"
+    systemctl status datadog-agent
+    # No salimos con error para permitir que el resto del script continúe
+  fi
+done
+
+# Iniciar y habilitar el servicio de Docker
+echo "Iniciando el servicio Docker..."
+systemctl start docker
+systemctl enable docker
+
+# Verificar que Docker esté en funcionamiento
+echo "Verificando que Docker esté en funcionamiento..."
+for i in {1..5}; do
+  if systemctl is-active docker >/dev/null 2>&1; then
+    echo "Docker se ha iniciado correctamente"
+    break
+  else
+    echo "Esperando a que Docker se inicie (intento $i/5)..."
+    sleep 10
+    systemctl start docker
+  fi
+  
+  if [ $i -eq 5 ]; then
+    echo "ERROR: No se pudo iniciar Docker después de 5 intentos"
+    systemctl status docker
+    exit 1
+  fi
+done
+
+# Asegurarse de que el usuario ec2-user pueda usar Docker sin sudo
+echo "Configurando permisos de Docker para ec2-user..."
+usermod -aG docker ec2-user
+# Reiniciar Docker para aplicar los cambios de grupo
+systemctl restart docker
+sleep 5
 
 # Descargar y descomprimir el archivo frontend.zip desde S3
-aws s3 cp s3://lti-project-code-bucket-jlso/frontend.zip /home/ec2-user/frontend.zip
-unzip /home/ec2-user/frontend.zip -d /home/ec2-user/
+echo "Descargando y descomprimiendo el código del frontend..."
+aws s3 cp s3://lti-project-code-bucket-jlso/frontend.zip /home/ec2-user/frontend.zip || {
+    echo "ERROR: No se pudo descargar frontend.zip desde S3"
+    exit 1
+}
+unzip -o /home/ec2-user/frontend.zip -d /home/ec2-user/ || {
+    echo "ERROR: No se pudo descomprimir frontend.zip"
+    exit 1
+}
+
+# Verificar que el directorio del frontend existe
+if [ ! -d "/home/ec2-user/frontend" ]; then
+    echo "ERROR: No se encontró el directorio /home/ec2-user/frontend después de descomprimir"
+    ls -la /home/ec2-user/
+    exit 1
+fi
 
 # Construir la imagen Docker para el frontend
+echo "Construyendo imagen Docker para el frontend..."
 cd /home/ec2-user/frontend
-docker build -t lti-frontend .
+docker build -t lti-frontend . || {
+    echo "ERROR: Falló la construcción de la imagen Docker"
+    exit 1
+}
 
-# Ejecutar el contenedor Docker
-docker run -d -p 3000:3000 lti-frontend
+# Verificar si ya existe un contenedor con el mismo nombre
+echo "Verificando si ya existe un contenedor lti-frontend..."
+if docker ps -a | grep lti-frontend; then
+    echo "Eliminando contenedor existente lti-frontend..."
+    docker stop lti-frontend || true
+    docker rm lti-frontend || true
+fi
+
+# Ejecutar el contenedor Docker con etiquetas para Datadog
+echo "Iniciando contenedor Docker para el frontend..."
+INSTANCE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+docker run -d -p 3000:3000 \
+  --name lti-frontend \
+  -e DD_AGENT_HOST=$INSTANCE_IP \
+  -e DD_ENV=production \
+  -e DD_SERVICE=frontend \
+  -e DD_VERSION=1.0 \
+  lti-frontend
+
+# Verificar que el contenedor se haya iniciado correctamente
+echo "Verificando que el contenedor se haya iniciado correctamente..."
+sleep 10  # Aumentamos el tiempo de espera para dar más tiempo al contenedor para iniciar
+MAX_RETRIES=3
+for i in $(seq 1 $MAX_RETRIES); do
+  if docker ps | grep lti-frontend; then
+    echo "Contenedor lti-frontend iniciado correctamente"
+    # Verificar que el servicio responde
+    echo "Verificando que el servicio responde..."
+    sleep 5
+    if curl -s http://localhost:3000 > /dev/null; then
+      echo "El servicio frontend responde correctamente"
+      break
+    else
+      echo "El servicio no responde en el puerto 3000, pero el contenedor está en ejecución"
+      if [ $i -eq $MAX_RETRIES ]; then
+        echo "ADVERTENCIA: El servicio no responde después de $MAX_RETRIES intentos"
+        docker logs lti-frontend
+      else
+        echo "Reintentando en 10 segundos... (intento $i/$MAX_RETRIES)"
+        sleep 10
+      fi
+    fi
+  else
+    echo "ERROR: No se pudo iniciar el contenedor lti-frontend (intento $i/$MAX_RETRIES)"
+    docker logs lti-frontend
+    echo "Estado de Docker:"
+    systemctl status docker
+    echo "Imágenes disponibles:"
+    docker images
+    echo "Todos los contenedores:"
+    docker ps -a
+    
+    if [ $i -eq $MAX_RETRIES ]; then
+      echo "ERROR: No se pudo iniciar el contenedor después de $MAX_RETRIES intentos"
+    else
+      echo "Reintentando iniciar el contenedor... (intento $i/$MAX_RETRIES)"
+      docker run -d -p 3000:3000 \
+        --name lti-frontend \
+        -e DD_AGENT_HOST=$INSTANCE_IP \
+        -e DD_ENV=production \
+        -e DD_SERVICE=frontend \
+        -e DD_VERSION=1.0 \
+        lti-frontend
+      sleep 10
+    fi
+  fi
+done
+
+# Verificar la integración con Datadog
+echo "Verificando integración con Datadog..."
+if systemctl is-active datadog-agent >/dev/null 2>&1; then
+  echo "Agente Datadog está activo, verificando estado..."
+  datadog-agent status || echo "No se pudo obtener el estado del agente Datadog"
+  
+  # Verificar integración con Docker
+  echo "Verificando integración de Datadog con Docker..."
+  datadog-agent status | grep -A 10 docker || echo "No se encontró información sobre la integración con Docker"
+else
+  echo "ADVERTENCIA: El agente Datadog no está activo"
+fi
 
 # Timestamp to force update
+echo "Configuración completada: $(date)"
 echo "Timestamp: ${timestamp}"

--- a/tf/scripts/frontend_user_data.sh
+++ b/tf/scripts/frontend_user_data.sh
@@ -9,7 +9,7 @@ export DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-ag
 service docker start
 
 # Descargar y descomprimir el archivo frontend.zip desde S3
-aws s3 cp s3://lti-project-code-bucket/frontend.zip /home/ec2-user/frontend.zip
+aws s3 cp s3://lti-project-code-bucket-jlso/frontend.zip /home/ec2-user/frontend.zip
 unzip /home/ec2-user/frontend.zip -d /home/ec2-user/
 
 # Construir la imagen Docker para el frontend

--- a/tf/security_groups.tf
+++ b/tf/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "backend_sg" {
-  name        = "lti-project-backend-sg"
+  name        = "lti-project-backend-sg-jlso"
   description = "Allow HTTP and SSH access"
 
   ingress {
@@ -25,7 +25,7 @@ resource "aws_security_group" "backend_sg" {
 }
 
 resource "aws_security_group" "frontend_sg" {
-  name        = "lti-project-frontend-sg"
+  name        = "lti-project-frontend-sg-jlso"
   description = "Allow HTTP and SSH access"
 
   ingress {

--- a/tf/terraform.tfstate
+++ b/tf/terraform.tfstate
@@ -1,15 +1,23 @@
 {
   "version": 4,
-  "terraform_version": "1.5.7",
-  "serial": 65,
+  "terraform_version": "1.10.5",
+  "serial": 152,
   "lineage": "387e0128-7818-bd5e-f9a8-c5ef3d942ac4",
   "outputs": {
     "backend_instance_id": {
-      "value": "i-049315aac4f5f6fd8",
+      "value": "i-0c21033d703746a6c",
+      "type": "string"
+    },
+    "backend_public_ip": {
+      "value": "34.238.40.71",
       "type": "string"
     },
     "frontend_instance_id": {
-      "value": "i-0ae033544c52fb556",
+      "value": "i-0e880c3344a572c02",
+      "type": "string"
+    },
+    "frontend_public_ip": {
+      "value": "54.167.51.17",
       "type": "string"
     }
   },
@@ -24,7 +32,7 @@
           "schema_version": 0,
           "attributes": {
             "architecture": "x86_64",
-            "arn": "arn:aws:ec2:us-east-1::image/ami-075d39ebbca89ed55",
+            "arn": "arn:aws:ec2:us-east-1::image/ami-0ace34e9f53c91c5d",
             "block_device_mappings": [
               {
                 "device_name": "/dev/xvda",
@@ -32,7 +40,7 @@
                   "delete_on_termination": "true",
                   "encrypted": "false",
                   "iops": "0",
-                  "snapshot_id": "snap-0fdcc8d1d920eece2",
+                  "snapshot_id": "snap-0bf568edc120fa91f",
                   "throughput": "0",
                   "volume_size": "8",
                   "volume_type": "gp2"
@@ -42,9 +50,9 @@
               }
             ],
             "boot_mode": "",
-            "creation_date": "2024-08-17T04:00:23.000Z",
+            "creation_date": "2025-02-20T22:38:11.000Z",
             "deprecation_time": "2025-07-01T00:00:00.000Z",
-            "description": "Amazon Linux 2 AMI 2.0.20240816.0 x86_64 HVM gp2",
+            "description": "Amazon Linux 2 AMI 2.0.20250220.0 x86_64 HVM gp2",
             "ena_support": true,
             "executable_users": null,
             "filter": [
@@ -62,16 +70,16 @@
               }
             ],
             "hypervisor": "xen",
-            "id": "ami-075d39ebbca89ed55",
-            "image_id": "ami-075d39ebbca89ed55",
-            "image_location": "amazon/amzn2-ami-hvm-2.0.20240816.0-x86_64-gp2",
+            "id": "ami-0ace34e9f53c91c5d",
+            "image_id": "ami-0ace34e9f53c91c5d",
+            "image_location": "amazon/amzn2-ami-hvm-2.0.20250220.0-x86_64-gp2",
             "image_owner_alias": "amazon",
             "image_type": "machine",
             "imds_support": "",
             "include_deprecated": false,
             "kernel_id": "",
             "most_recent": true,
-            "name": "amzn2-ami-hvm-2.0.20240816.0-x86_64-gp2",
+            "name": "amzn2-ami-hvm-2.0.20250220.0-x86_64-gp2",
             "name_regex": null,
             "owner_id": "137112412989",
             "owners": [
@@ -84,7 +92,7 @@
             "ramdisk_id": "",
             "root_device_name": "/dev/xvda",
             "root_device_type": "ebs",
-            "root_snapshot_id": "snap-0fdcc8d1d920eece2",
+            "root_snapshot_id": "snap-0bf568edc120fa91f",
             "sriov_net_support": "simple",
             "state": "available",
             "state_reason": {
@@ -110,9 +118,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "1756601947",
-            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"arn:aws:s3:::lti-project-code-bucket/*\"\n    }\n  ]\n}",
-            "minified_json": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::lti-project-code-bucket/*\"}]}",
+            "id": "3348972686",
+            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"arn:aws:s3:::lti-project-code-bucket-jlso/*\"\n    }\n  ]\n}",
             "override_json": null,
             "override_policy_documents": null,
             "policy_id": null,
@@ -130,7 +137,7 @@
                 "not_resources": [],
                 "principals": [],
                 "resources": [
-                  "arn:aws:s3:::lti-project-code-bucket/*"
+                  "arn:aws:s3:::lti-project-code-bucket-jlso/*"
                 ],
                 "sid": ""
               }
@@ -160,19 +167,19 @@
             ],
             "id": "us-east-1",
             "ids": [
-              "i-0ae033544c52fb556",
-              "i-049315aac4f5f6fd8"
+              "i-074b0bbd1dd0a8082",
+              "i-09de555f0afde2819"
             ],
             "instance_state_names": null,
             "instance_tags": null,
             "ipv6_addresses": [],
             "private_ips": [
-              "172.31.25.252",
-              "172.31.95.72"
+              "172.31.20.240",
+              "172.31.94.246"
             ],
             "public_ips": [
-              "98.80.123.52",
-              "44.201.169.118"
+              "54.227.189.221",
+              "18.204.199.84"
             ],
             "timeouts": null
           },
@@ -189,8 +196,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:instance-profile/lti-project-ec2-instance-profile",
-            "create_date": "2024-09-02T16:50:31Z",
+            "arn": "arn:aws:iam::076836058049:instance-profile/lti-project-ec2-instance-profile",
+            "create_date": "2025-02-27T03:40:49Z",
             "id": "lti-project-ec2-instance-profile",
             "name": "lti-project-ec2-instance-profile",
             "name_prefix": "",
@@ -198,7 +205,7 @@
             "role": "lti-project-ec2-role",
             "tags": {},
             "tags_all": {},
-            "unique_id": "AIPATG6MGXLEN5J5E5LRX"
+            "unique_id": "AIPARDY6JGPASAE3QN4GJ"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -217,16 +224,15 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:policy/DatadogPolicy",
-            "attachment_count": 0,
-            "description": "Política para permitir a Datadog acceder a CloudWatch",
-            "id": "arn:aws:iam::221082204872:policy/DatadogPolicy",
-            "name": "DatadogPolicy",
+            "arn": "arn:aws:iam::076836058049:policy/DatadogPolicy-jlso",
+            "description": "PolÃ­tica para permitir a Datadog acceder a CloudWatch",
+            "id": "arn:aws:iam::076836058049:policy/DatadogPolicy-jlso",
+            "name": "DatadogPolicy-jlso",
             "name_prefix": "",
             "path": "/",
-            "policy": "{\"Statement\":[{\"Action\":[\"cloudwatch:GetMetricData\",\"cloudwatch:ListMetrics\",\"ec2:DescribeInstances\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\",\"logs:GetLogEvents\",\"logs:FilterLogEvents\",\"tag:GetResources\",\"tag:GetTagKeys\",\"tag:GetTagValues\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
-            "policy_id": "ANPATG6MGXLEJM6IG5BL5",
-            "tags": {},
+            "policy": "{\"Statement\":[{\"Action\":[\"cloudwatch:GetMetricData\",\"cloudwatch:ListMetrics\",\"cloudwatch:GetMetricStatistics\",\"ec2:DescribeInstances\",\"ec2:DescribeRegions\",\"ec2:DescribeTags\",\"ec2:DescribeVolumes\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\",\"logs:GetLogEvents\",\"logs:FilterLogEvents\",\"tag:GetResources\",\"tag:GetTagKeys\",\"tag:GetTagValues\",\"cloudtrail:LookupEvents\",\"cloudtrail:GetTrailStatus\",\"cloudtrail:DescribeTrails\",\"health:DescribeEvents\",\"health:DescribeEventDetails\",\"health:DescribeAffectedEntities\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPARDY6JGPA67COC57P7",
+            "tags": null,
             "tags_all": {}
           },
           "sensitive_attributes": [],
@@ -243,15 +249,14 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:policy/s3-access-policy",
-            "attachment_count": 1,
+            "arn": "arn:aws:iam::076836058049:policy/s3-access-policy",
             "description": "",
-            "id": "arn:aws:iam::221082204872:policy/s3-access-policy",
+            "id": "arn:aws:iam::076836058049:policy/s3-access-policy",
             "name": "s3-access-policy",
             "name_prefix": "",
             "path": "/",
-            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::lti-project-code-bucket/*\"}],\"Version\":\"2012-10-17\"}",
-            "policy_id": "ANPATG6MGXLEKV6W5SZL2",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::lti-project-code-bucket-jlso/*\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPARDY6JGPA6QHA6ZOTQ",
             "tags": {},
             "tags_all": {}
           },
@@ -273,24 +278,30 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:role/lti-project-ec2-role",
+            "arn": "arn:aws:iam::076836058049:role/lti-project-ec2-role",
             "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
-            "create_date": "2024-09-02T16:50:30Z",
+            "create_date": "2025-02-27T03:40:48Z",
             "description": "",
             "force_detach_policies": false,
             "id": "lti-project-ec2-role",
             "inline_policy": [],
             "managed_policy_arns": [
-              "arn:aws:iam::221082204872:policy/s3-access-policy"
+              "arn:aws:iam::076836058049:policy/s3-access-policy"
             ],
             "max_session_duration": 3600,
             "name": "lti-project-ec2-role",
             "name_prefix": "",
             "path": "/",
             "permissions_boundary": "",
+            "role_last_used": [
+              {
+                "last_used_date": "2025-03-01T18:38:52Z",
+                "region": "us-east-1"
+              }
+            ],
             "tags": {},
             "tags_all": {},
-            "unique_id": "AROATG6MGXLEMSXDTLEFW"
+            "unique_id": "AROARDY6JGPA6OUOPMKYK"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA=="
@@ -306,8 +317,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "lti-project-ec2-role-20240902165032030200000001",
-            "policy_arn": "arn:aws:iam::221082204872:policy/s3-access-policy",
+            "id": "lti-project-ec2-role-20250228040309854500000001",
+            "policy_arn": "arn:aws:iam::076836058049:policy/s3-access-policy",
             "role": "lti-project-ec2-role"
           },
           "sensitive_attributes": [],
@@ -330,10 +341,10 @@
         {
           "schema_version": 1,
           "attributes": {
-            "ami": "ami-075d39ebbca89ed55",
-            "arn": "arn:aws:ec2:us-east-1:221082204872:instance/i-049315aac4f5f6fd8",
+            "ami": "ami-0ace34e9f53c91c5d",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:instance/i-0c21033d703746a6c",
             "associate_public_ip_address": true,
-            "availability_zone": "us-east-1d",
+            "availability_zone": "us-east-1b",
             "capacity_reservation_specification": [
               {
                 "capacity_reservation_preference": "open",
@@ -369,10 +380,8 @@
             "host_id": "",
             "host_resource_group_arn": null,
             "iam_instance_profile": "lti-project-ec2-instance-profile",
-            "id": "i-049315aac4f5f6fd8",
+            "id": "i-0c21033d703746a6c",
             "instance_initiated_shutdown_behavior": "stop",
-            "instance_lifecycle": "",
-            "instance_market_options": [],
             "instance_state": "running",
             "instance_type": "t2.micro",
             "ipv6_address_count": 0,
@@ -387,7 +396,6 @@
             "metadata_options": [
               {
                 "http_endpoint": "enabled",
-                "http_protocol_ipv6": "disabled",
                 "http_put_response_hop_limit": 1,
                 "http_tokens": "optional",
                 "instance_metadata_tags": "disabled"
@@ -399,8 +407,8 @@
             "password_data": "",
             "placement_group": "",
             "placement_partition_number": 0,
-            "primary_network_interface_id": "eni-038af989c7c50032a",
-            "private_dns": "ip-172-31-95-72.ec2.internal",
+            "primary_network_interface_id": "eni-04801d28baa9d4cb7",
+            "private_dns": "ip-172-31-80-91.ec2.internal",
             "private_dns_name_options": [
               {
                 "enable_resource_name_dns_a_record": false,
@@ -408,9 +416,9 @@
                 "hostname_type": "ip-name"
               }
             ],
-            "private_ip": "172.31.95.72",
-            "public_dns": "ec2-52-91-73-30.compute-1.amazonaws.com",
-            "public_ip": "52.91.73.30",
+            "private_ip": "172.31.80.91",
+            "public_dns": "ec2-34-238-40-71.compute-1.amazonaws.com",
+            "public_ip": "34.238.40.71",
             "root_block_device": [
               {
                 "delete_on_termination": true,
@@ -419,42 +427,43 @@
                 "iops": 100,
                 "kms_key_id": "",
                 "tags": {},
-                "tags_all": {},
                 "throughput": 0,
-                "volume_id": "vol-088aa007d8b1a51cc",
+                "volume_id": "vol-03bf491d79dd26032",
                 "volume_size": 8,
                 "volume_type": "gp2"
               }
             ],
             "secondary_private_ips": [],
             "security_groups": [
-              "lti-project-backend-sg"
+              "lti-project-backend-sg-jlso"
             ],
             "source_dest_check": true,
-            "spot_instance_request_id": "",
-            "subnet_id": "subnet-04111fea7659260e3",
+            "subnet_id": "subnet-0d076ae29640fc05b",
             "tags": {
               "Datadog": "true",
-              "Name": "lti-project-backend"
+              "Name": "lti-project-backend",
+              "ScriptHash": "9e1fb5938e580473f00fd7a5fbc02740"
             },
             "tags_all": {
               "Datadog": "true",
-              "Name": "lti-project-backend"
+              "Name": "lti-project-backend",
+              "ScriptHash": "9e1fb5938e580473f00fd7a5fbc02740"
             },
             "tenancy": "default",
             "timeouts": null,
-            "user_data": "ba330a2cb0d4709874e7d9ca62a24f30960b1b41",
+            "user_data": "940c0bff7d6513582385847d041a8d1ad12b9de5",
             "user_data_base64": null,
-            "user_data_replace_on_change": false,
+            "user_data_replace_on_change": true,
             "volume_tags": null,
             "vpc_security_group_ids": [
-              "sg-063f33e895b0b3520"
+              "sg-02de136a91b69ff5c"
             ]
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
           "dependencies": [
             "aws_iam_instance_profile.ec2_instance_profile",
+            "aws_iam_role.ec2_role",
             "aws_security_group.backend_sg",
             "data.aws_ami.amazon_linux"
           ]
@@ -470,10 +479,10 @@
         {
           "schema_version": 1,
           "attributes": {
-            "ami": "ami-075d39ebbca89ed55",
-            "arn": "arn:aws:ec2:us-east-1:221082204872:instance/i-0ae033544c52fb556",
+            "ami": "ami-0ace34e9f53c91c5d",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:instance/i-0e880c3344a572c02",
             "associate_public_ip_address": true,
-            "availability_zone": "us-east-1a",
+            "availability_zone": "us-east-1c",
             "capacity_reservation_specification": [
               {
                 "capacity_reservation_preference": "open",
@@ -509,10 +518,8 @@
             "host_id": "",
             "host_resource_group_arn": null,
             "iam_instance_profile": "lti-project-ec2-instance-profile",
-            "id": "i-0ae033544c52fb556",
+            "id": "i-0e880c3344a572c02",
             "instance_initiated_shutdown_behavior": "stop",
-            "instance_lifecycle": "",
-            "instance_market_options": [],
             "instance_state": "running",
             "instance_type": "t2.medium",
             "ipv6_address_count": 0,
@@ -527,7 +534,6 @@
             "metadata_options": [
               {
                 "http_endpoint": "enabled",
-                "http_protocol_ipv6": "disabled",
                 "http_put_response_hop_limit": 1,
                 "http_tokens": "optional",
                 "instance_metadata_tags": "disabled"
@@ -539,8 +545,8 @@
             "password_data": "",
             "placement_group": "",
             "placement_partition_number": 0,
-            "primary_network_interface_id": "eni-05060c812241020d9",
-            "private_dns": "ip-172-31-25-252.ec2.internal",
+            "primary_network_interface_id": "eni-047ad0bf9dd05c22c",
+            "private_dns": "ip-172-31-27-151.ec2.internal",
             "private_dns_name_options": [
               {
                 "enable_resource_name_dns_a_record": false,
@@ -548,9 +554,9 @@
                 "hostname_type": "ip-name"
               }
             ],
-            "private_ip": "172.31.25.252",
-            "public_dns": "ec2-52-91-38-28.compute-1.amazonaws.com",
-            "public_ip": "52.91.38.28",
+            "private_ip": "172.31.27.151",
+            "public_dns": "ec2-54-167-51-17.compute-1.amazonaws.com",
+            "public_ip": "54.167.51.17",
             "root_block_device": [
               {
                 "delete_on_termination": true,
@@ -559,42 +565,43 @@
                 "iops": 100,
                 "kms_key_id": "",
                 "tags": {},
-                "tags_all": {},
                 "throughput": 0,
-                "volume_id": "vol-099ab4d5e7018abf5",
+                "volume_id": "vol-013d13bc1deedb87b",
                 "volume_size": 8,
                 "volume_type": "gp2"
               }
             ],
             "secondary_private_ips": [],
             "security_groups": [
-              "lti-project-frontend-sg"
+              "lti-project-frontend-sg-jlso"
             ],
             "source_dest_check": true,
-            "spot_instance_request_id": "",
-            "subnet_id": "subnet-0a6620ec76cfceb3b",
+            "subnet_id": "subnet-04f6892fc106e2228",
             "tags": {
               "Datadog": "true",
-              "Name": "lti-project-frontend"
+              "Name": "lti-project-frontend",
+              "ScriptHash": "d370a73250420f401178c4687a93f2cb"
             },
             "tags_all": {
               "Datadog": "true",
-              "Name": "lti-project-frontend"
+              "Name": "lti-project-frontend",
+              "ScriptHash": "d370a73250420f401178c4687a93f2cb"
             },
             "tenancy": "default",
             "timeouts": null,
-            "user_data": "f8342c3a0a1ddca9b5889715736920a6c19b8de6",
+            "user_data": "717060205e878db57d04211c6bb5abfd8d74361b",
             "user_data_base64": null,
-            "user_data_replace_on_change": false,
+            "user_data_replace_on_change": true,
             "volume_tags": null,
             "vpc_security_group_ids": [
-              "sg-0fae59be49af042b8"
+              "sg-0c2b8ef5d2157cf20"
             ]
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
           "dependencies": [
             "aws_iam_instance_profile.ec2_instance_profile",
+            "aws_iam_role.ec2_role",
             "aws_security_group.frontend_sg",
             "data.aws_ami.amazon_linux"
           ]
@@ -611,17 +618,17 @@
           "schema_version": 0,
           "attributes": {
             "acceleration_status": "",
-            "acl": "private",
-            "arn": "arn:aws:s3:::lti-project-code-bucket",
-            "bucket": "lti-project-code-bucket",
-            "bucket_domain_name": "lti-project-code-bucket.s3.amazonaws.com",
+            "acl": null,
+            "arn": "arn:aws:s3:::lti-project-code-bucket-jlso",
+            "bucket": "lti-project-code-bucket-jlso",
+            "bucket_domain_name": "lti-project-code-bucket-jlso.s3.amazonaws.com",
             "bucket_prefix": "",
-            "bucket_regional_domain_name": "lti-project-code-bucket.s3.us-east-1.amazonaws.com",
+            "bucket_regional_domain_name": "lti-project-code-bucket-jlso.s3.amazonaws.com",
             "cors_rule": [],
             "force_destroy": false,
             "grant": [
               {
-                "id": "baf283b4ff6364e4dc27023f9c3cf45021c219a8b084ec66b4631e7ae94a68b6",
+                "id": "87c2645280992506f2a209034ba7a76974580cb7f710455d1785df0cd579750d",
                 "permissions": [
                   "FULL_CONTROL"
                 ],
@@ -630,7 +637,7 @@
               }
             ],
             "hosted_zone_id": "Z3AQBSTGFYJSTF",
-            "id": "lti-project-code-bucket",
+            "id": "lti-project-code-bucket-jlso",
             "lifecycle_rule": [],
             "logging": [],
             "object_lock_configuration": [],
@@ -674,7 +681,32 @@
     },
     {
       "mode": "managed",
-      "type": "aws_s3_bucket_object",
+      "type": "aws_s3_bucket_ownership_controls",
+      "name": "code_bucket_ownership",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "lti-project-code-bucket-jlso",
+            "id": "lti-project-code-bucket-jlso",
+            "rule": [
+              {
+                "object_ownership": "BucketOwnerEnforced"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.code_bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_object",
       "name": "backend_zip",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
@@ -682,8 +714,7 @@
           "schema_version": 0,
           "attributes": {
             "acl": "private",
-            "arn": "arn:aws:s3:::lti-project-code-bucket/backend.zip",
-            "bucket": "lti-project-code-bucket",
+            "bucket": "lti-project-code-bucket-jlso",
             "bucket_key_enabled": false,
             "cache_control": "",
             "content": null,
@@ -691,7 +722,7 @@
             "content_disposition": "",
             "content_encoding": "",
             "content_language": "",
-            "content_type": "application/octet-stream",
+            "content_type": "binary/octet-stream",
             "etag": "733be52824c6c6f3b4dd53fb553a051c",
             "force_destroy": false,
             "id": "backend.zip",
@@ -714,6 +745,7 @@
           "private": "bnVsbA==",
           "dependencies": [
             "aws_s3_bucket.code_bucket",
+            "aws_s3_bucket_ownership_controls.code_bucket_ownership",
             "null_resource.generate_zip"
           ]
         }
@@ -721,7 +753,7 @@
     },
     {
       "mode": "managed",
-      "type": "aws_s3_bucket_object",
+      "type": "aws_s3_object",
       "name": "frontend_zip",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
@@ -729,8 +761,7 @@
           "schema_version": 0,
           "attributes": {
             "acl": "private",
-            "arn": "arn:aws:s3:::lti-project-code-bucket/frontend.zip",
-            "bucket": "lti-project-code-bucket",
+            "bucket": "lti-project-code-bucket-jlso",
             "bucket_key_enabled": false,
             "cache_control": "",
             "content": null,
@@ -738,7 +769,7 @@
             "content_disposition": "",
             "content_encoding": "",
             "content_language": "",
-            "content_type": "application/octet-stream",
+            "content_type": "binary/octet-stream",
             "etag": "b43637823b460710665a3181ca89f4e9",
             "force_destroy": false,
             "id": "frontend.zip",
@@ -761,6 +792,7 @@
           "private": "bnVsbA==",
           "dependencies": [
             "aws_s3_bucket.code_bucket",
+            "aws_s3_bucket_ownership_controls.code_bucket_ownership",
             "null_resource.generate_zip"
           ]
         }
@@ -775,7 +807,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:221082204872:security-group/sg-063f33e895b0b3520",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:security-group/sg-02de136a91b69ff5c",
             "description": "Allow HTTP and SSH access",
             "egress": [
               {
@@ -792,7 +824,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-063f33e895b0b3520",
+            "id": "sg-02de136a91b69ff5c",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -821,14 +853,14 @@
                 "to_port": 8080
               }
             ],
-            "name": "lti-project-backend-sg",
+            "name": "lti-project-backend-sg-jlso",
             "name_prefix": "",
-            "owner_id": "221082204872",
+            "owner_id": "076836058049",
             "revoke_rules_on_delete": false,
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0c2301a918f033073"
+            "vpc_id": "vpc-007e9b1a9fa74e27d"
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
@@ -844,7 +876,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:221082204872:security-group/sg-0fae59be49af042b8",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:security-group/sg-0c2b8ef5d2157cf20",
             "description": "Allow HTTP and SSH access",
             "egress": [
               {
@@ -861,7 +893,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-0fae59be49af042b8",
+            "id": "sg-0c2b8ef5d2157cf20",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -890,14 +922,14 @@
                 "to_port": 3000
               }
             ],
-            "name": "lti-project-frontend-sg",
+            "name": "lti-project-frontend-sg-jlso",
             "name_prefix": "",
-            "owner_id": "221082204872",
+            "owner_id": "076836058049",
             "revoke_rules_on_delete": false,
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0c2301a918f033073"
+            "vpc_id": "vpc-007e9b1a9fa74e27d"
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
@@ -915,8 +947,8 @@
           "attributes": {
             "dashboard_lists": null,
             "dashboard_lists_removed": [],
-            "description": "Dashboard para monitorizar instancias EC2",
-            "id": "vgi-9cw-79i",
+            "description": "Dashboard para monitorizar instancias EC2 - Creado por JLSO",
+            "id": "nxe-yem-jyp",
             "is_read_only": false,
             "layout_type": "ordered",
             "notify_list": [],
@@ -925,8 +957,8 @@
             "tags": [],
             "template_variable": [],
             "template_variable_preset": [],
-            "title": "EC2 Monitoring Dashboard",
-            "url": "/dashboard/vgi-9cw-79i/ec2-monitoring-dashboard",
+            "title": "EC2 Monitoring Dashboard - JLSO",
+            "url": "/dashboard/nxe-yem-jyp/ec2-monitoring-dashboard---jlso",
             "widget": [
               {
                 "alert_graph_definition": [],
@@ -938,10 +970,238 @@
                 "event_timeline_definition": [],
                 "free_text_definition": [],
                 "geomap_definition": [],
-                "group_definition": [],
+                "group_definition": [
+                  {
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "CPU Metrics",
+                    "widget": [
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 8817352981671415,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.cpuutilization{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "CPU Utilization",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": [
+                              {
+                                "include_zero": false,
+                                "label": "",
+                                "max": "100",
+                                "min": "0",
+                                "scale": "linear"
+                              }
+                            ]
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 5169392733068434,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.cpucredit_usage{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "CPU Credit Usage",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 8830755072166687,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.cpucredit_balance{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "CPU Credit Balance",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      }
+                    ]
+                  }
+                ],
                 "heatmap_definition": [],
                 "hostmap_definition": [],
-                "id": 8463191981068380,
+                "id": 1165055353049032,
                 "iframe_definition": [],
                 "image_definition": [],
                 "list_stream_definition": [],
@@ -958,41 +1218,810 @@
                 "slo_list_definition": [],
                 "split_graph_definition": [],
                 "sunburst_definition": [],
-                "timeseries_definition": [
+                "timeseries_definition": [],
+                "toplist_definition": [],
+                "topology_map_definition": [],
+                "trace_service_definition": [],
+                "treemap_definition": [],
+                "widget_layout": []
+              },
+              {
+                "alert_graph_definition": [],
+                "alert_value_definition": [],
+                "change_definition": [],
+                "check_status_definition": [],
+                "distribution_definition": [],
+                "event_stream_definition": [],
+                "event_timeline_definition": [],
+                "free_text_definition": [],
+                "geomap_definition": [],
+                "group_definition": [
                   {
-                    "custom_link": [],
-                    "event": [],
-                    "legend_columns": [],
-                    "legend_layout": "",
-                    "legend_size": "",
-                    "live_span": "",
-                    "marker": [],
-                    "request": [
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "Memory Metrics",
+                    "widget": [
                       {
-                        "apm_query": [],
-                        "audit_query": [],
-                        "display_type": "",
-                        "formula": [],
-                        "log_query": [],
-                        "metadata": [],
-                        "network_query": [],
-                        "on_right_yaxis": false,
-                        "process_query": [],
-                        "q": "avg:aws.ec2.cpuutilization{*} by {instance_id}",
-                        "query": [],
-                        "rum_query": [],
-                        "security_query": [],
-                        "style": []
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 6587249148552485,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.mem.used{*} by {host}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Memory Used",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 6225925472534246,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.mem.free{*} by {host}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Memory Free",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 8996098305446665,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.mem.used{*} by {host} / avg:system.mem.total{*} by {host} * 100",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Memory Usage (%)",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": [
+                              {
+                                "include_zero": false,
+                                "label": "",
+                                "max": "100",
+                                "min": "0",
+                                "scale": "linear"
+                              }
+                            ]
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
                       }
-                    ],
-                    "right_yaxis": [],
-                    "show_legend": false,
-                    "title": "CPU Utilization",
-                    "title_align": "",
-                    "title_size": "",
-                    "yaxis": []
+                    ]
                   }
                 ],
+                "heatmap_definition": [],
+                "hostmap_definition": [],
+                "id": 4973893131431854,
+                "iframe_definition": [],
+                "image_definition": [],
+                "list_stream_definition": [],
+                "log_stream_definition": [],
+                "manage_status_definition": [],
+                "note_definition": [],
+                "powerpack_definition": [],
+                "query_table_definition": [],
+                "query_value_definition": [],
+                "run_workflow_definition": [],
+                "scatterplot_definition": [],
+                "service_level_objective_definition": [],
+                "servicemap_definition": [],
+                "slo_list_definition": [],
+                "split_graph_definition": [],
+                "sunburst_definition": [],
+                "timeseries_definition": [],
+                "toplist_definition": [],
+                "topology_map_definition": [],
+                "trace_service_definition": [],
+                "treemap_definition": [],
+                "widget_layout": []
+              },
+              {
+                "alert_graph_definition": [],
+                "alert_value_definition": [],
+                "change_definition": [],
+                "check_status_definition": [],
+                "distribution_definition": [],
+                "event_stream_definition": [],
+                "event_timeline_definition": [],
+                "free_text_definition": [],
+                "geomap_definition": [],
+                "group_definition": [
+                  {
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "Network Metrics",
+                    "widget": [
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 7977145337102549,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_in{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Network In",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 1360221982148534,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_out{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Network Out",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 5638581970025362,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_packets_in{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              },
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_packets_out{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Network Packets In/Out",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      }
+                    ]
+                  }
+                ],
+                "heatmap_definition": [],
+                "hostmap_definition": [],
+                "id": 8334159348843580,
+                "iframe_definition": [],
+                "image_definition": [],
+                "list_stream_definition": [],
+                "log_stream_definition": [],
+                "manage_status_definition": [],
+                "note_definition": [],
+                "powerpack_definition": [],
+                "query_table_definition": [],
+                "query_value_definition": [],
+                "run_workflow_definition": [],
+                "scatterplot_definition": [],
+                "service_level_objective_definition": [],
+                "servicemap_definition": [],
+                "slo_list_definition": [],
+                "split_graph_definition": [],
+                "sunburst_definition": [],
+                "timeseries_definition": [],
+                "toplist_definition": [],
+                "topology_map_definition": [],
+                "trace_service_definition": [],
+                "treemap_definition": [],
+                "widget_layout": []
+              },
+              {
+                "alert_graph_definition": [],
+                "alert_value_definition": [],
+                "change_definition": [],
+                "check_status_definition": [],
+                "distribution_definition": [],
+                "event_stream_definition": [],
+                "event_timeline_definition": [],
+                "free_text_definition": [],
+                "geomap_definition": [],
+                "group_definition": [
+                  {
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "Disk Metrics",
+                    "widget": [
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 1475489054566809,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.disk_read_bytes{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Disk Read Bytes",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 289983314445336,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.disk_write_bytes{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Disk Write Bytes",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 3525039130735848,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.disk.in_use{*} by {host,device} * 100",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Disk Usage (%)",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": [
+                              {
+                                "include_zero": false,
+                                "label": "",
+                                "max": "100",
+                                "min": "0",
+                                "scale": "linear"
+                              }
+                            ]
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      }
+                    ]
+                  }
+                ],
+                "heatmap_definition": [],
+                "hostmap_definition": [],
+                "id": 2359243068844286,
+                "iframe_definition": [],
+                "image_definition": [],
+                "list_stream_definition": [],
+                "log_stream_definition": [],
+                "manage_status_definition": [],
+                "note_definition": [],
+                "powerpack_definition": [],
+                "query_table_definition": [],
+                "query_value_definition": [],
+                "run_workflow_definition": [],
+                "scatterplot_definition": [],
+                "service_level_objective_definition": [],
+                "servicemap_definition": [],
+                "slo_list_definition": [],
+                "split_graph_definition": [],
+                "sunburst_definition": [],
+                "timeseries_definition": [],
                 "toplist_definition": [],
                 "topology_map_definition": [],
                 "trace_service_definition": [],
@@ -1012,7 +2041,7 @@
                 "group_definition": [],
                 "heatmap_definition": [],
                 "hostmap_definition": [],
-                "id": 2056185183310877,
+                "id": 6573297333858929,
                 "iframe_definition": [],
                 "image_definition": [],
                 "list_stream_definition": [],
@@ -1029,42 +2058,32 @@
                 "slo_list_definition": [],
                 "split_graph_definition": [],
                 "sunburst_definition": [],
-                "timeseries_definition": [
+                "timeseries_definition": [],
+                "toplist_definition": [
                   {
                     "custom_link": [],
-                    "event": [],
-                    "legend_columns": [],
-                    "legend_layout": "",
-                    "legend_size": "",
                     "live_span": "",
-                    "marker": [],
                     "request": [
                       {
                         "apm_query": [],
                         "audit_query": [],
-                        "display_type": "",
+                        "conditional_formats": [],
                         "formula": [],
                         "log_query": [],
-                        "metadata": [],
-                        "network_query": [],
-                        "on_right_yaxis": false,
                         "process_query": [],
-                        "q": "avg:aws.ec2.network_in{*} by {instance_id}",
+                        "q": "top(avg:aws.ec2.cpuutilization{*} by {instance_id}, 10, 'mean', 'desc')",
                         "query": [],
                         "rum_query": [],
                         "security_query": [],
                         "style": []
                       }
                     ],
-                    "right_yaxis": [],
-                    "show_legend": false,
-                    "title": "Network In",
+                    "style": [],
+                    "title": "Top Instances by CPU Usage",
                     "title_align": "",
-                    "title_size": "",
-                    "yaxis": []
+                    "title_size": ""
                   }
                 ],
-                "toplist_definition": [],
                 "topology_map_definition": [],
                 "trace_service_definition": [],
                 "treemap_definition": [],
@@ -1083,13 +2102,25 @@
                 "group_definition": [],
                 "heatmap_definition": [],
                 "hostmap_definition": [],
-                "id": 1751003529301049,
+                "id": 8488248833146635,
                 "iframe_definition": [],
                 "image_definition": [],
                 "list_stream_definition": [],
                 "log_stream_definition": [],
                 "manage_status_definition": [],
-                "note_definition": [],
+                "note_definition": [
+                  {
+                    "background_color": "gray",
+                    "content": "Dashboard creado con Terraform para monitorizar instancias EC2 en AWS. Última actualización: 01-03-2025",
+                    "font_size": "14",
+                    "has_padding": true,
+                    "show_tick": true,
+                    "text_align": "center",
+                    "tick_edge": "bottom",
+                    "tick_pos": "bottom",
+                    "vertical_align": ""
+                  }
+                ],
                 "powerpack_definition": [],
                 "query_table_definition": [],
                 "query_value_definition": [],
@@ -1100,41 +2131,7 @@
                 "slo_list_definition": [],
                 "split_graph_definition": [],
                 "sunburst_definition": [],
-                "timeseries_definition": [
-                  {
-                    "custom_link": [],
-                    "event": [],
-                    "legend_columns": [],
-                    "legend_layout": "",
-                    "legend_size": "",
-                    "live_span": "",
-                    "marker": [],
-                    "request": [
-                      {
-                        "apm_query": [],
-                        "audit_query": [],
-                        "display_type": "",
-                        "formula": [],
-                        "log_query": [],
-                        "metadata": [],
-                        "network_query": [],
-                        "on_right_yaxis": false,
-                        "process_query": [],
-                        "q": "avg:aws.ec2.network_out{*} by {instance_id}",
-                        "query": [],
-                        "rum_query": [],
-                        "security_query": [],
-                        "style": []
-                      }
-                    ],
-                    "right_yaxis": [],
-                    "show_legend": false,
-                    "title": "Network Out",
-                    "title_align": "",
-                    "title_size": "",
-                    "yaxis": []
-                  }
-                ],
+                "timeseries_definition": [],
                 "toplist_definition": [],
                 "topology_map_definition": [],
                 "trace_service_definition": [],
@@ -1150,6 +2147,266 @@
     },
     {
       "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "ec2_status_check",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675237",
+            "include_tags": true,
+            "locked": false,
+            "message": "La instancia EC2 no está pasando los status checks durante más de 5 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "0",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Instancia EC2 no disponible - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 10,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": true,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "min(last_5m):avg:aws.ec2.status_check_failed{*} by {instance_id} \u003e 0",
+            "renotify_interval": 30,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "high_cpu",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675240",
+            "include_tags": true,
+            "locked": false,
+            "message": "La utilización de CPU está por encima del 80% durante más de 5 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "80",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "70",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Alta utilización de CPU en instancias EC2 - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 0,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": false,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "avg(last_5m):avg:aws.ec2.cpuutilization{*} by {instance_id} \u003e 80",
+            "renotify_interval": 60,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "high_disk",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675239",
+            "include_tags": true,
+            "locked": false,
+            "message": "El uso de disco está por encima del 85% durante más de 10 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "85",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "75",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Alto uso de disco en instancias EC2 - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 0,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": false,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "avg(last_10m):avg:system.disk.in_use{*} by {host,device} * 100 \u003e 85",
+            "renotify_interval": 60,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "high_memory",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675238",
+            "include_tags": true,
+            "locked": false,
+            "message": "La utilización de memoria está por encima del 85% durante más de 5 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "85",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "75",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Alta utilización de memoria en instancias EC2 - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 0,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": false,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "avg(last_5m):avg:system.mem.used{*} by {host} / avg:system.mem.total{*} by {host} * 100 \u003e 85",
+            "renotify_interval": 60,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
       "type": "null_resource",
       "name": "generate_zip",
       "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
@@ -1157,9 +2414,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "8958389625023456746",
+            "id": "5346693206766755602",
             "triggers": {
-              "always_run": "2024-09-03T02:24:32Z"
+              "always_run": "2025-03-01T19:14:24Z"
             }
           },
           "sensitive_attributes": []

--- a/tf/terraform.tfstate.backup
+++ b/tf/terraform.tfstate.backup
@@ -1,15 +1,23 @@
 {
   "version": 4,
-  "terraform_version": "1.5.7",
-  "serial": 60,
+  "terraform_version": "1.10.5",
+  "serial": 143,
   "lineage": "387e0128-7818-bd5e-f9a8-c5ef3d942ac4",
   "outputs": {
     "backend_instance_id": {
-      "value": "i-049315aac4f5f6fd8",
+      "value": "i-09de555f0afde2819",
+      "type": "string"
+    },
+    "backend_public_ip": {
+      "value": "18.204.199.84",
       "type": "string"
     },
     "frontend_instance_id": {
-      "value": "i-0ae033544c52fb556",
+      "value": "i-074b0bbd1dd0a8082",
+      "type": "string"
+    },
+    "frontend_public_ip": {
+      "value": "54.227.189.221",
       "type": "string"
     }
   },
@@ -24,7 +32,7 @@
           "schema_version": 0,
           "attributes": {
             "architecture": "x86_64",
-            "arn": "arn:aws:ec2:us-east-1::image/ami-075d39ebbca89ed55",
+            "arn": "arn:aws:ec2:us-east-1::image/ami-0ace34e9f53c91c5d",
             "block_device_mappings": [
               {
                 "device_name": "/dev/xvda",
@@ -32,7 +40,7 @@
                   "delete_on_termination": "true",
                   "encrypted": "false",
                   "iops": "0",
-                  "snapshot_id": "snap-0fdcc8d1d920eece2",
+                  "snapshot_id": "snap-0bf568edc120fa91f",
                   "throughput": "0",
                   "volume_size": "8",
                   "volume_type": "gp2"
@@ -42,9 +50,9 @@
               }
             ],
             "boot_mode": "",
-            "creation_date": "2024-08-17T04:00:23.000Z",
+            "creation_date": "2025-02-20T22:38:11.000Z",
             "deprecation_time": "2025-07-01T00:00:00.000Z",
-            "description": "Amazon Linux 2 AMI 2.0.20240816.0 x86_64 HVM gp2",
+            "description": "Amazon Linux 2 AMI 2.0.20250220.0 x86_64 HVM gp2",
             "ena_support": true,
             "executable_users": null,
             "filter": [
@@ -62,16 +70,16 @@
               }
             ],
             "hypervisor": "xen",
-            "id": "ami-075d39ebbca89ed55",
-            "image_id": "ami-075d39ebbca89ed55",
-            "image_location": "amazon/amzn2-ami-hvm-2.0.20240816.0-x86_64-gp2",
+            "id": "ami-0ace34e9f53c91c5d",
+            "image_id": "ami-0ace34e9f53c91c5d",
+            "image_location": "amazon/amzn2-ami-hvm-2.0.20250220.0-x86_64-gp2",
             "image_owner_alias": "amazon",
             "image_type": "machine",
             "imds_support": "",
             "include_deprecated": false,
             "kernel_id": "",
             "most_recent": true,
-            "name": "amzn2-ami-hvm-2.0.20240816.0-x86_64-gp2",
+            "name": "amzn2-ami-hvm-2.0.20250220.0-x86_64-gp2",
             "name_regex": null,
             "owner_id": "137112412989",
             "owners": [
@@ -84,7 +92,7 @@
             "ramdisk_id": "",
             "root_device_name": "/dev/xvda",
             "root_device_type": "ebs",
-            "root_snapshot_id": "snap-0fdcc8d1d920eece2",
+            "root_snapshot_id": "snap-0bf568edc120fa91f",
             "sriov_net_support": "simple",
             "state": "available",
             "state_reason": {
@@ -110,9 +118,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "1756601947",
-            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"arn:aws:s3:::lti-project-code-bucket/*\"\n    }\n  ]\n}",
-            "minified_json": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::lti-project-code-bucket/*\"}]}",
+            "id": "3348972686",
+            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"arn:aws:s3:::lti-project-code-bucket-jlso/*\"\n    }\n  ]\n}",
             "override_json": null,
             "override_policy_documents": null,
             "policy_id": null,
@@ -130,7 +137,7 @@
                 "not_resources": [],
                 "principals": [],
                 "resources": [
-                  "arn:aws:s3:::lti-project-code-bucket/*"
+                  "arn:aws:s3:::lti-project-code-bucket-jlso/*"
                 ],
                 "sid": ""
               }
@@ -160,19 +167,19 @@
             ],
             "id": "us-east-1",
             "ids": [
-              "i-0ae033544c52fb556",
-              "i-049315aac4f5f6fd8"
+              "i-0f3238ac56f2b4a0b",
+              "i-050a8c77f02b268ba"
             ],
             "instance_state_names": null,
             "instance_tags": null,
             "ipv6_addresses": [],
             "private_ips": [
-              "172.31.25.252",
-              "172.31.95.72"
+              "172.31.25.255",
+              "172.31.86.102"
             ],
             "public_ips": [
-              "54.226.90.25",
-              "54.159.146.15"
+              "3.80.222.170",
+              "3.87.73.176"
             ],
             "timeouts": null
           },
@@ -189,8 +196,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:instance-profile/lti-project-ec2-instance-profile",
-            "create_date": "2024-09-02T16:50:31Z",
+            "arn": "arn:aws:iam::076836058049:instance-profile/lti-project-ec2-instance-profile",
+            "create_date": "2025-02-27T03:40:49Z",
             "id": "lti-project-ec2-instance-profile",
             "name": "lti-project-ec2-instance-profile",
             "name_prefix": "",
@@ -198,7 +205,7 @@
             "role": "lti-project-ec2-role",
             "tags": {},
             "tags_all": {},
-            "unique_id": "AIPATG6MGXLEN5J5E5LRX"
+            "unique_id": "AIPARDY6JGPASAE3QN4GJ"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -217,16 +224,15 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:policy/DatadogPolicy",
-            "attachment_count": 0,
-            "description": "Política para permitir a Datadog acceder a CloudWatch",
-            "id": "arn:aws:iam::221082204872:policy/DatadogPolicy",
-            "name": "DatadogPolicy",
+            "arn": "arn:aws:iam::076836058049:policy/DatadogPolicy-jlso",
+            "description": "PolÃ­tica para permitir a Datadog acceder a CloudWatch",
+            "id": "arn:aws:iam::076836058049:policy/DatadogPolicy-jlso",
+            "name": "DatadogPolicy-jlso",
             "name_prefix": "",
             "path": "/",
-            "policy": "{\"Statement\":[{\"Action\":[\"cloudwatch:GetMetricData\",\"cloudwatch:ListMetrics\",\"ec2:DescribeInstances\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\",\"logs:GetLogEvents\",\"logs:FilterLogEvents\",\"tag:GetResources\",\"tag:GetTagKeys\",\"tag:GetTagValues\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
-            "policy_id": "ANPATG6MGXLEJM6IG5BL5",
-            "tags": {},
+            "policy": "{\"Statement\":[{\"Action\":[\"cloudwatch:GetMetricData\",\"cloudwatch:ListMetrics\",\"cloudwatch:GetMetricStatistics\",\"ec2:DescribeInstances\",\"ec2:DescribeRegions\",\"ec2:DescribeTags\",\"ec2:DescribeVolumes\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\",\"logs:GetLogEvents\",\"logs:FilterLogEvents\",\"tag:GetResources\",\"tag:GetTagKeys\",\"tag:GetTagValues\",\"cloudtrail:LookupEvents\",\"cloudtrail:GetTrailStatus\",\"cloudtrail:DescribeTrails\",\"health:DescribeEvents\",\"health:DescribeEventDetails\",\"health:DescribeAffectedEntities\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPARDY6JGPA4Y3Z7ZE6A",
+            "tags": null,
             "tags_all": {}
           },
           "sensitive_attributes": [],
@@ -243,15 +249,14 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:policy/s3-access-policy",
-            "attachment_count": 1,
+            "arn": "arn:aws:iam::076836058049:policy/s3-access-policy",
             "description": "",
-            "id": "arn:aws:iam::221082204872:policy/s3-access-policy",
+            "id": "arn:aws:iam::076836058049:policy/s3-access-policy",
             "name": "s3-access-policy",
             "name_prefix": "",
             "path": "/",
-            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::lti-project-code-bucket/*\"}],\"Version\":\"2012-10-17\"}",
-            "policy_id": "ANPATG6MGXLEKV6W5SZL2",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::lti-project-code-bucket-jlso/*\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPARDY6JGPA6QHA6ZOTQ",
             "tags": {},
             "tags_all": {}
           },
@@ -273,24 +278,30 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:iam::221082204872:role/lti-project-ec2-role",
+            "arn": "arn:aws:iam::076836058049:role/lti-project-ec2-role",
             "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
-            "create_date": "2024-09-02T16:50:30Z",
+            "create_date": "2025-02-27T03:40:48Z",
             "description": "",
             "force_detach_policies": false,
             "id": "lti-project-ec2-role",
             "inline_policy": [],
             "managed_policy_arns": [
-              "arn:aws:iam::221082204872:policy/s3-access-policy"
+              "arn:aws:iam::076836058049:policy/s3-access-policy"
             ],
             "max_session_duration": 3600,
             "name": "lti-project-ec2-role",
             "name_prefix": "",
             "path": "/",
             "permissions_boundary": "",
+            "role_last_used": [
+              {
+                "last_used_date": "2025-03-01T18:13:49Z",
+                "region": "us-east-1"
+              }
+            ],
             "tags": {},
             "tags_all": {},
-            "unique_id": "AROATG6MGXLEMSXDTLEFW"
+            "unique_id": "AROARDY6JGPA6OUOPMKYK"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA=="
@@ -306,8 +317,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "lti-project-ec2-role-20240902165032030200000001",
-            "policy_arn": "arn:aws:iam::221082204872:policy/s3-access-policy",
+            "id": "lti-project-ec2-role-20250228040309854500000001",
+            "policy_arn": "arn:aws:iam::076836058049:policy/s3-access-policy",
             "role": "lti-project-ec2-role"
           },
           "sensitive_attributes": [],
@@ -330,10 +341,10 @@
         {
           "schema_version": 1,
           "attributes": {
-            "ami": "ami-075d39ebbca89ed55",
-            "arn": "arn:aws:ec2:us-east-1:221082204872:instance/i-049315aac4f5f6fd8",
+            "ami": "ami-0ace34e9f53c91c5d",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:instance/i-09de555f0afde2819",
             "associate_public_ip_address": true,
-            "availability_zone": "us-east-1d",
+            "availability_zone": "us-east-1b",
             "capacity_reservation_specification": [
               {
                 "capacity_reservation_preference": "open",
@@ -369,10 +380,8 @@
             "host_id": "",
             "host_resource_group_arn": null,
             "iam_instance_profile": "lti-project-ec2-instance-profile",
-            "id": "i-049315aac4f5f6fd8",
+            "id": "i-09de555f0afde2819",
             "instance_initiated_shutdown_behavior": "stop",
-            "instance_lifecycle": "",
-            "instance_market_options": [],
             "instance_state": "running",
             "instance_type": "t2.micro",
             "ipv6_address_count": 0,
@@ -387,7 +396,6 @@
             "metadata_options": [
               {
                 "http_endpoint": "enabled",
-                "http_protocol_ipv6": "disabled",
                 "http_put_response_hop_limit": 1,
                 "http_tokens": "optional",
                 "instance_metadata_tags": "disabled"
@@ -399,8 +407,8 @@
             "password_data": "",
             "placement_group": "",
             "placement_partition_number": 0,
-            "primary_network_interface_id": "eni-038af989c7c50032a",
-            "private_dns": "ip-172-31-95-72.ec2.internal",
+            "primary_network_interface_id": "eni-078874a97c18b7566",
+            "private_dns": "ip-172-31-94-246.ec2.internal",
             "private_dns_name_options": [
               {
                 "enable_resource_name_dns_a_record": false,
@@ -408,9 +416,9 @@
                 "hostname_type": "ip-name"
               }
             ],
-            "private_ip": "172.31.95.72",
-            "public_dns": "ec2-44-201-169-118.compute-1.amazonaws.com",
-            "public_ip": "44.201.169.118",
+            "private_ip": "172.31.94.246",
+            "public_dns": "ec2-18-204-199-84.compute-1.amazonaws.com",
+            "public_ip": "18.204.199.84",
             "root_block_device": [
               {
                 "delete_on_termination": true,
@@ -419,42 +427,43 @@
                 "iops": 100,
                 "kms_key_id": "",
                 "tags": {},
-                "tags_all": {},
                 "throughput": 0,
-                "volume_id": "vol-088aa007d8b1a51cc",
+                "volume_id": "vol-041344ffe6e94dd4b",
                 "volume_size": 8,
                 "volume_type": "gp2"
               }
             ],
             "secondary_private_ips": [],
             "security_groups": [
-              "lti-project-backend-sg"
+              "lti-project-backend-sg-jlso"
             ],
             "source_dest_check": true,
-            "spot_instance_request_id": "",
-            "subnet_id": "subnet-04111fea7659260e3",
+            "subnet_id": "subnet-0d076ae29640fc05b",
             "tags": {
               "Datadog": "true",
-              "Name": "lti-project-backend"
+              "Name": "lti-project-backend",
+              "ScriptHash": "ce2812618a7accccc5f8618903116e2f"
             },
             "tags_all": {
               "Datadog": "true",
-              "Name": "lti-project-backend"
+              "Name": "lti-project-backend",
+              "ScriptHash": "ce2812618a7accccc5f8618903116e2f"
             },
             "tenancy": "default",
             "timeouts": null,
-            "user_data": "a05ca947972e312716ea5e8c87d906d5b252cbeb",
+            "user_data": "47b3cfa62abe7d82c3f8b50bd31cea281a6bc3f0",
             "user_data_base64": null,
-            "user_data_replace_on_change": false,
+            "user_data_replace_on_change": true,
             "volume_tags": null,
             "vpc_security_group_ids": [
-              "sg-063f33e895b0b3520"
+              "sg-02de136a91b69ff5c"
             ]
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
           "dependencies": [
             "aws_iam_instance_profile.ec2_instance_profile",
+            "aws_iam_role.ec2_role",
             "aws_security_group.backend_sg",
             "data.aws_ami.amazon_linux"
           ]
@@ -470,10 +479,10 @@
         {
           "schema_version": 1,
           "attributes": {
-            "ami": "ami-075d39ebbca89ed55",
-            "arn": "arn:aws:ec2:us-east-1:221082204872:instance/i-0ae033544c52fb556",
+            "ami": "ami-0ace34e9f53c91c5d",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:instance/i-074b0bbd1dd0a8082",
             "associate_public_ip_address": true,
-            "availability_zone": "us-east-1a",
+            "availability_zone": "us-east-1c",
             "capacity_reservation_specification": [
               {
                 "capacity_reservation_preference": "open",
@@ -509,10 +518,8 @@
             "host_id": "",
             "host_resource_group_arn": null,
             "iam_instance_profile": "lti-project-ec2-instance-profile",
-            "id": "i-0ae033544c52fb556",
+            "id": "i-074b0bbd1dd0a8082",
             "instance_initiated_shutdown_behavior": "stop",
-            "instance_lifecycle": "",
-            "instance_market_options": [],
             "instance_state": "running",
             "instance_type": "t2.medium",
             "ipv6_address_count": 0,
@@ -527,7 +534,6 @@
             "metadata_options": [
               {
                 "http_endpoint": "enabled",
-                "http_protocol_ipv6": "disabled",
                 "http_put_response_hop_limit": 1,
                 "http_tokens": "optional",
                 "instance_metadata_tags": "disabled"
@@ -539,8 +545,8 @@
             "password_data": "",
             "placement_group": "",
             "placement_partition_number": 0,
-            "primary_network_interface_id": "eni-05060c812241020d9",
-            "private_dns": "ip-172-31-25-252.ec2.internal",
+            "primary_network_interface_id": "eni-0f3967ac945f623ef",
+            "private_dns": "ip-172-31-20-240.ec2.internal",
             "private_dns_name_options": [
               {
                 "enable_resource_name_dns_a_record": false,
@@ -548,9 +554,9 @@
                 "hostname_type": "ip-name"
               }
             ],
-            "private_ip": "172.31.25.252",
-            "public_dns": "ec2-98-80-123-52.compute-1.amazonaws.com",
-            "public_ip": "98.80.123.52",
+            "private_ip": "172.31.20.240",
+            "public_dns": "ec2-54-227-189-221.compute-1.amazonaws.com",
+            "public_ip": "54.227.189.221",
             "root_block_device": [
               {
                 "delete_on_termination": true,
@@ -559,42 +565,43 @@
                 "iops": 100,
                 "kms_key_id": "",
                 "tags": {},
-                "tags_all": {},
                 "throughput": 0,
-                "volume_id": "vol-099ab4d5e7018abf5",
+                "volume_id": "vol-00f2b32e4756b30fb",
                 "volume_size": 8,
                 "volume_type": "gp2"
               }
             ],
             "secondary_private_ips": [],
             "security_groups": [
-              "lti-project-frontend-sg"
+              "lti-project-frontend-sg-jlso"
             ],
             "source_dest_check": true,
-            "spot_instance_request_id": "",
-            "subnet_id": "subnet-0a6620ec76cfceb3b",
+            "subnet_id": "subnet-04f6892fc106e2228",
             "tags": {
               "Datadog": "true",
-              "Name": "lti-project-frontend"
+              "Name": "lti-project-frontend",
+              "ScriptHash": "ea3e5cf275989a99124c0f196e826ab0"
             },
             "tags_all": {
               "Datadog": "true",
-              "Name": "lti-project-frontend"
+              "Name": "lti-project-frontend",
+              "ScriptHash": "ea3e5cf275989a99124c0f196e826ab0"
             },
             "tenancy": "default",
             "timeouts": null,
-            "user_data": "35879fd6ef72d8b8ecfd3b25e066c82ed008ee86",
+            "user_data": "6c075ecae3ab14274120f853c631830b93e3fa59",
             "user_data_base64": null,
-            "user_data_replace_on_change": false,
+            "user_data_replace_on_change": true,
             "volume_tags": null,
             "vpc_security_group_ids": [
-              "sg-0fae59be49af042b8"
+              "sg-0c2b8ef5d2157cf20"
             ]
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
           "dependencies": [
             "aws_iam_instance_profile.ec2_instance_profile",
+            "aws_iam_role.ec2_role",
             "aws_security_group.frontend_sg",
             "data.aws_ami.amazon_linux"
           ]
@@ -611,17 +618,17 @@
           "schema_version": 0,
           "attributes": {
             "acceleration_status": "",
-            "acl": "private",
-            "arn": "arn:aws:s3:::lti-project-code-bucket",
-            "bucket": "lti-project-code-bucket",
-            "bucket_domain_name": "lti-project-code-bucket.s3.amazonaws.com",
+            "acl": null,
+            "arn": "arn:aws:s3:::lti-project-code-bucket-jlso",
+            "bucket": "lti-project-code-bucket-jlso",
+            "bucket_domain_name": "lti-project-code-bucket-jlso.s3.amazonaws.com",
             "bucket_prefix": "",
-            "bucket_regional_domain_name": "lti-project-code-bucket.s3.us-east-1.amazonaws.com",
+            "bucket_regional_domain_name": "lti-project-code-bucket-jlso.s3.amazonaws.com",
             "cors_rule": [],
             "force_destroy": false,
             "grant": [
               {
-                "id": "baf283b4ff6364e4dc27023f9c3cf45021c219a8b084ec66b4631e7ae94a68b6",
+                "id": "87c2645280992506f2a209034ba7a76974580cb7f710455d1785df0cd579750d",
                 "permissions": [
                   "FULL_CONTROL"
                 ],
@@ -630,7 +637,7 @@
               }
             ],
             "hosted_zone_id": "Z3AQBSTGFYJSTF",
-            "id": "lti-project-code-bucket",
+            "id": "lti-project-code-bucket-jlso",
             "lifecycle_rule": [],
             "logging": [],
             "object_lock_configuration": [],
@@ -674,7 +681,32 @@
     },
     {
       "mode": "managed",
-      "type": "aws_s3_bucket_object",
+      "type": "aws_s3_bucket_ownership_controls",
+      "name": "code_bucket_ownership",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "lti-project-code-bucket-jlso",
+            "id": "lti-project-code-bucket-jlso",
+            "rule": [
+              {
+                "object_ownership": "BucketOwnerEnforced"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.code_bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_object",
       "name": "backend_zip",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
@@ -682,8 +714,7 @@
           "schema_version": 0,
           "attributes": {
             "acl": "private",
-            "arn": "arn:aws:s3:::lti-project-code-bucket/backend.zip",
-            "bucket": "lti-project-code-bucket",
+            "bucket": "lti-project-code-bucket-jlso",
             "bucket_key_enabled": false,
             "cache_control": "",
             "content": null,
@@ -691,7 +722,7 @@
             "content_disposition": "",
             "content_encoding": "",
             "content_language": "",
-            "content_type": "application/octet-stream",
+            "content_type": "binary/octet-stream",
             "etag": "733be52824c6c6f3b4dd53fb553a051c",
             "force_destroy": false,
             "id": "backend.zip",
@@ -714,6 +745,7 @@
           "private": "bnVsbA==",
           "dependencies": [
             "aws_s3_bucket.code_bucket",
+            "aws_s3_bucket_ownership_controls.code_bucket_ownership",
             "null_resource.generate_zip"
           ]
         }
@@ -721,7 +753,7 @@
     },
     {
       "mode": "managed",
-      "type": "aws_s3_bucket_object",
+      "type": "aws_s3_object",
       "name": "frontend_zip",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
@@ -729,8 +761,7 @@
           "schema_version": 0,
           "attributes": {
             "acl": "private",
-            "arn": "arn:aws:s3:::lti-project-code-bucket/frontend.zip",
-            "bucket": "lti-project-code-bucket",
+            "bucket": "lti-project-code-bucket-jlso",
             "bucket_key_enabled": false,
             "cache_control": "",
             "content": null,
@@ -738,7 +769,7 @@
             "content_disposition": "",
             "content_encoding": "",
             "content_language": "",
-            "content_type": "application/octet-stream",
+            "content_type": "binary/octet-stream",
             "etag": "b43637823b460710665a3181ca89f4e9",
             "force_destroy": false,
             "id": "frontend.zip",
@@ -761,6 +792,7 @@
           "private": "bnVsbA==",
           "dependencies": [
             "aws_s3_bucket.code_bucket",
+            "aws_s3_bucket_ownership_controls.code_bucket_ownership",
             "null_resource.generate_zip"
           ]
         }
@@ -775,7 +807,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:221082204872:security-group/sg-063f33e895b0b3520",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:security-group/sg-02de136a91b69ff5c",
             "description": "Allow HTTP and SSH access",
             "egress": [
               {
@@ -792,7 +824,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-063f33e895b0b3520",
+            "id": "sg-02de136a91b69ff5c",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -821,14 +853,14 @@
                 "to_port": 8080
               }
             ],
-            "name": "lti-project-backend-sg",
+            "name": "lti-project-backend-sg-jlso",
             "name_prefix": "",
-            "owner_id": "221082204872",
+            "owner_id": "076836058049",
             "revoke_rules_on_delete": false,
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0c2301a918f033073"
+            "vpc_id": "vpc-007e9b1a9fa74e27d"
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
@@ -844,7 +876,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:221082204872:security-group/sg-0fae59be49af042b8",
+            "arn": "arn:aws:ec2:us-east-1:076836058049:security-group/sg-0c2b8ef5d2157cf20",
             "description": "Allow HTTP and SSH access",
             "egress": [
               {
@@ -861,7 +893,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-0fae59be49af042b8",
+            "id": "sg-0c2b8ef5d2157cf20",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -890,14 +922,14 @@
                 "to_port": 3000
               }
             ],
-            "name": "lti-project-frontend-sg",
+            "name": "lti-project-frontend-sg-jlso",
             "name_prefix": "",
-            "owner_id": "221082204872",
+            "owner_id": "076836058049",
             "revoke_rules_on_delete": false,
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0c2301a918f033073"
+            "vpc_id": "vpc-007e9b1a9fa74e27d"
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
@@ -915,8 +947,8 @@
           "attributes": {
             "dashboard_lists": null,
             "dashboard_lists_removed": [],
-            "description": "Dashboard para monitorizar instancias EC2",
-            "id": "vgi-9cw-79i",
+            "description": "Dashboard para monitorizar instancias EC2 - Creado por JLSO",
+            "id": "nxe-yem-jyp",
             "is_read_only": false,
             "layout_type": "ordered",
             "notify_list": [],
@@ -925,8 +957,8 @@
             "tags": [],
             "template_variable": [],
             "template_variable_preset": [],
-            "title": "EC2 Monitoring Dashboard",
-            "url": "/dashboard/vgi-9cw-79i/ec2-monitoring-dashboard",
+            "title": "EC2 Monitoring Dashboard - JLSO",
+            "url": "/dashboard/nxe-yem-jyp/ec2-monitoring-dashboard---jlso",
             "widget": [
               {
                 "alert_graph_definition": [],
@@ -938,10 +970,238 @@
                 "event_timeline_definition": [],
                 "free_text_definition": [],
                 "geomap_definition": [],
-                "group_definition": [],
+                "group_definition": [
+                  {
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "CPU Metrics",
+                    "widget": [
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 8817352981671415,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.cpuutilization{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "CPU Utilization",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": [
+                              {
+                                "include_zero": false,
+                                "label": "",
+                                "max": "100",
+                                "min": "0",
+                                "scale": "linear"
+                              }
+                            ]
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 5169392733068434,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.cpucredit_usage{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "CPU Credit Usage",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 8830755072166687,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.cpucredit_balance{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "CPU Credit Balance",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      }
+                    ]
+                  }
+                ],
                 "heatmap_definition": [],
                 "hostmap_definition": [],
-                "id": 8463191981068380,
+                "id": 1165055353049032,
                 "iframe_definition": [],
                 "image_definition": [],
                 "list_stream_definition": [],
@@ -958,41 +1218,810 @@
                 "slo_list_definition": [],
                 "split_graph_definition": [],
                 "sunburst_definition": [],
-                "timeseries_definition": [
+                "timeseries_definition": [],
+                "toplist_definition": [],
+                "topology_map_definition": [],
+                "trace_service_definition": [],
+                "treemap_definition": [],
+                "widget_layout": []
+              },
+              {
+                "alert_graph_definition": [],
+                "alert_value_definition": [],
+                "change_definition": [],
+                "check_status_definition": [],
+                "distribution_definition": [],
+                "event_stream_definition": [],
+                "event_timeline_definition": [],
+                "free_text_definition": [],
+                "geomap_definition": [],
+                "group_definition": [
                   {
-                    "custom_link": [],
-                    "event": [],
-                    "legend_columns": [],
-                    "legend_layout": "",
-                    "legend_size": "",
-                    "live_span": "",
-                    "marker": [],
-                    "request": [
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "Memory Metrics",
+                    "widget": [
                       {
-                        "apm_query": [],
-                        "audit_query": [],
-                        "display_type": "",
-                        "formula": [],
-                        "log_query": [],
-                        "metadata": [],
-                        "network_query": [],
-                        "on_right_yaxis": false,
-                        "process_query": [],
-                        "q": "avg:aws.ec2.cpuutilization{*} by {instance_id}",
-                        "query": [],
-                        "rum_query": [],
-                        "security_query": [],
-                        "style": []
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 6587249148552485,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.mem.used{*} by {host}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Memory Used",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 6225925472534246,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.mem.free{*} by {host}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Memory Free",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 8996098305446665,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.mem.used{*} by {host} / avg:system.mem.total{*} by {host} * 100",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Memory Usage (%)",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": [
+                              {
+                                "include_zero": false,
+                                "label": "",
+                                "max": "100",
+                                "min": "0",
+                                "scale": "linear"
+                              }
+                            ]
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
                       }
-                    ],
-                    "right_yaxis": [],
-                    "show_legend": false,
-                    "title": "CPU Utilization",
-                    "title_align": "",
-                    "title_size": "",
-                    "yaxis": []
+                    ]
                   }
                 ],
+                "heatmap_definition": [],
+                "hostmap_definition": [],
+                "id": 4973893131431854,
+                "iframe_definition": [],
+                "image_definition": [],
+                "list_stream_definition": [],
+                "log_stream_definition": [],
+                "manage_status_definition": [],
+                "note_definition": [],
+                "powerpack_definition": [],
+                "query_table_definition": [],
+                "query_value_definition": [],
+                "run_workflow_definition": [],
+                "scatterplot_definition": [],
+                "service_level_objective_definition": [],
+                "servicemap_definition": [],
+                "slo_list_definition": [],
+                "split_graph_definition": [],
+                "sunburst_definition": [],
+                "timeseries_definition": [],
+                "toplist_definition": [],
+                "topology_map_definition": [],
+                "trace_service_definition": [],
+                "treemap_definition": [],
+                "widget_layout": []
+              },
+              {
+                "alert_graph_definition": [],
+                "alert_value_definition": [],
+                "change_definition": [],
+                "check_status_definition": [],
+                "distribution_definition": [],
+                "event_stream_definition": [],
+                "event_timeline_definition": [],
+                "free_text_definition": [],
+                "geomap_definition": [],
+                "group_definition": [
+                  {
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "Network Metrics",
+                    "widget": [
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 7977145337102549,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_in{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Network In",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 1360221982148534,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_out{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Network Out",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 5638581970025362,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_packets_in{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              },
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.network_packets_out{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Network Packets In/Out",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      }
+                    ]
+                  }
+                ],
+                "heatmap_definition": [],
+                "hostmap_definition": [],
+                "id": 8334159348843580,
+                "iframe_definition": [],
+                "image_definition": [],
+                "list_stream_definition": [],
+                "log_stream_definition": [],
+                "manage_status_definition": [],
+                "note_definition": [],
+                "powerpack_definition": [],
+                "query_table_definition": [],
+                "query_value_definition": [],
+                "run_workflow_definition": [],
+                "scatterplot_definition": [],
+                "service_level_objective_definition": [],
+                "servicemap_definition": [],
+                "slo_list_definition": [],
+                "split_graph_definition": [],
+                "sunburst_definition": [],
+                "timeseries_definition": [],
+                "toplist_definition": [],
+                "topology_map_definition": [],
+                "trace_service_definition": [],
+                "treemap_definition": [],
+                "widget_layout": []
+              },
+              {
+                "alert_graph_definition": [],
+                "alert_value_definition": [],
+                "change_definition": [],
+                "check_status_definition": [],
+                "distribution_definition": [],
+                "event_stream_definition": [],
+                "event_timeline_definition": [],
+                "free_text_definition": [],
+                "geomap_definition": [],
+                "group_definition": [
+                  {
+                    "background_color": "",
+                    "banner_img": "",
+                    "layout_type": "ordered",
+                    "show_title": true,
+                    "title": "Disk Metrics",
+                    "widget": [
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 1475489054566809,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.disk_read_bytes{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Disk Read Bytes",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 289983314445336,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "area",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:aws.ec2.disk_write_bytes{*} by {instance_id}",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Disk Write Bytes",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": []
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      },
+                      {
+                        "alert_graph_definition": [],
+                        "alert_value_definition": [],
+                        "change_definition": [],
+                        "check_status_definition": [],
+                        "distribution_definition": [],
+                        "event_stream_definition": [],
+                        "event_timeline_definition": [],
+                        "free_text_definition": [],
+                        "geomap_definition": [],
+                        "heatmap_definition": [],
+                        "hostmap_definition": [],
+                        "id": 3525039130735848,
+                        "iframe_definition": [],
+                        "image_definition": [],
+                        "list_stream_definition": [],
+                        "log_stream_definition": [],
+                        "manage_status_definition": [],
+                        "note_definition": [],
+                        "powerpack_definition": [],
+                        "query_table_definition": [],
+                        "query_value_definition": [],
+                        "run_workflow_definition": [],
+                        "scatterplot_definition": [],
+                        "service_level_objective_definition": [],
+                        "servicemap_definition": [],
+                        "slo_list_definition": [],
+                        "split_graph_definition": [],
+                        "sunburst_definition": [],
+                        "timeseries_definition": [
+                          {
+                            "custom_link": [],
+                            "event": [],
+                            "legend_columns": [],
+                            "legend_layout": "",
+                            "legend_size": "",
+                            "live_span": "",
+                            "marker": [],
+                            "request": [
+                              {
+                                "apm_query": [],
+                                "audit_query": [],
+                                "display_type": "line",
+                                "formula": [],
+                                "log_query": [],
+                                "metadata": [],
+                                "network_query": [],
+                                "on_right_yaxis": false,
+                                "process_query": [],
+                                "q": "avg:system.disk.in_use{*} by {host,device} * 100",
+                                "query": [],
+                                "rum_query": [],
+                                "security_query": [],
+                                "style": []
+                              }
+                            ],
+                            "right_yaxis": [],
+                            "show_legend": false,
+                            "title": "Disk Usage (%)",
+                            "title_align": "",
+                            "title_size": "",
+                            "yaxis": [
+                              {
+                                "include_zero": false,
+                                "label": "",
+                                "max": "100",
+                                "min": "0",
+                                "scale": "linear"
+                              }
+                            ]
+                          }
+                        ],
+                        "toplist_definition": [],
+                        "topology_map_definition": [],
+                        "trace_service_definition": [],
+                        "treemap_definition": [],
+                        "widget_layout": []
+                      }
+                    ]
+                  }
+                ],
+                "heatmap_definition": [],
+                "hostmap_definition": [],
+                "id": 2359243068844286,
+                "iframe_definition": [],
+                "image_definition": [],
+                "list_stream_definition": [],
+                "log_stream_definition": [],
+                "manage_status_definition": [],
+                "note_definition": [],
+                "powerpack_definition": [],
+                "query_table_definition": [],
+                "query_value_definition": [],
+                "run_workflow_definition": [],
+                "scatterplot_definition": [],
+                "service_level_objective_definition": [],
+                "servicemap_definition": [],
+                "slo_list_definition": [],
+                "split_graph_definition": [],
+                "sunburst_definition": [],
+                "timeseries_definition": [],
                 "toplist_definition": [],
                 "topology_map_definition": [],
                 "trace_service_definition": [],
@@ -1012,7 +2041,7 @@
                 "group_definition": [],
                 "heatmap_definition": [],
                 "hostmap_definition": [],
-                "id": 2056185183310877,
+                "id": 6573297333858929,
                 "iframe_definition": [],
                 "image_definition": [],
                 "list_stream_definition": [],
@@ -1029,42 +2058,32 @@
                 "slo_list_definition": [],
                 "split_graph_definition": [],
                 "sunburst_definition": [],
-                "timeseries_definition": [
+                "timeseries_definition": [],
+                "toplist_definition": [
                   {
                     "custom_link": [],
-                    "event": [],
-                    "legend_columns": [],
-                    "legend_layout": "",
-                    "legend_size": "",
                     "live_span": "",
-                    "marker": [],
                     "request": [
                       {
                         "apm_query": [],
                         "audit_query": [],
-                        "display_type": "",
+                        "conditional_formats": [],
                         "formula": [],
                         "log_query": [],
-                        "metadata": [],
-                        "network_query": [],
-                        "on_right_yaxis": false,
                         "process_query": [],
-                        "q": "avg:aws.ec2.network_in{*} by {instance_id}",
+                        "q": "top(avg:aws.ec2.cpuutilization{*} by {instance_id}, 10, 'mean', 'desc')",
                         "query": [],
                         "rum_query": [],
                         "security_query": [],
                         "style": []
                       }
                     ],
-                    "right_yaxis": [],
-                    "show_legend": false,
-                    "title": "Network In",
+                    "style": [],
+                    "title": "Top Instances by CPU Usage",
                     "title_align": "",
-                    "title_size": "",
-                    "yaxis": []
+                    "title_size": ""
                   }
                 ],
-                "toplist_definition": [],
                 "topology_map_definition": [],
                 "trace_service_definition": [],
                 "treemap_definition": [],
@@ -1083,13 +2102,25 @@
                 "group_definition": [],
                 "heatmap_definition": [],
                 "hostmap_definition": [],
-                "id": 1751003529301049,
+                "id": 8488248833146635,
                 "iframe_definition": [],
                 "image_definition": [],
                 "list_stream_definition": [],
                 "log_stream_definition": [],
                 "manage_status_definition": [],
-                "note_definition": [],
+                "note_definition": [
+                  {
+                    "background_color": "gray",
+                    "content": "Dashboard creado con Terraform para monitorizar instancias EC2 en AWS. Última actualización: 01-03-2025",
+                    "font_size": "14",
+                    "has_padding": true,
+                    "show_tick": true,
+                    "text_align": "center",
+                    "tick_edge": "bottom",
+                    "tick_pos": "bottom",
+                    "vertical_align": ""
+                  }
+                ],
                 "powerpack_definition": [],
                 "query_table_definition": [],
                 "query_value_definition": [],
@@ -1100,41 +2131,7 @@
                 "slo_list_definition": [],
                 "split_graph_definition": [],
                 "sunburst_definition": [],
-                "timeseries_definition": [
-                  {
-                    "custom_link": [],
-                    "event": [],
-                    "legend_columns": [],
-                    "legend_layout": "",
-                    "legend_size": "",
-                    "live_span": "",
-                    "marker": [],
-                    "request": [
-                      {
-                        "apm_query": [],
-                        "audit_query": [],
-                        "display_type": "",
-                        "formula": [],
-                        "log_query": [],
-                        "metadata": [],
-                        "network_query": [],
-                        "on_right_yaxis": false,
-                        "process_query": [],
-                        "q": "avg:aws.ec2.network_out{*} by {instance_id=i-0ae033544c52fb556}",
-                        "query": [],
-                        "rum_query": [],
-                        "security_query": [],
-                        "style": []
-                      }
-                    ],
-                    "right_yaxis": [],
-                    "show_legend": false,
-                    "title": "Network Out",
-                    "title_align": "",
-                    "title_size": "",
-                    "yaxis": []
-                  }
-                ],
+                "timeseries_definition": [],
                 "toplist_definition": [],
                 "topology_map_definition": [],
                 "trace_service_definition": [],
@@ -1150,6 +2147,266 @@
     },
     {
       "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "ec2_status_check",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675237",
+            "include_tags": true,
+            "locked": false,
+            "message": "La instancia EC2 no está pasando los status checks durante más de 5 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "0",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Instancia EC2 no disponible - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 10,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": true,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "min(last_5m):avg:aws.ec2.status_check_failed{*} by {instance_id} \u003e 0",
+            "renotify_interval": 30,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "high_cpu",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675240",
+            "include_tags": true,
+            "locked": false,
+            "message": "La utilización de CPU está por encima del 80% durante más de 5 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "80",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "70",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Alta utilización de CPU en instancias EC2 - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 0,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": false,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "avg(last_5m):avg:aws.ec2.cpuutilization{*} by {instance_id} \u003e 80",
+            "renotify_interval": 60,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "high_disk",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675239",
+            "include_tags": true,
+            "locked": false,
+            "message": "El uso de disco está por encima del 85% durante más de 10 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "85",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "75",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Alto uso de disco en instancias EC2 - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 0,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": false,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "avg(last_10m):avg:system.disk.in_use{*} by {host,device} * 100 \u003e 85",
+            "renotify_interval": 60,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "datadog_monitor",
+      "name": "high_memory",
+      "provider": "provider[\"registry.terraform.io/datadog/datadog\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_logs_sample": null,
+            "enable_samples": null,
+            "escalation_message": "",
+            "evaluation_delay": 60,
+            "force_delete": null,
+            "group_retention_duration": "",
+            "groupby_simple_monitor": null,
+            "id": "165675238",
+            "include_tags": true,
+            "locked": false,
+            "message": "La utilización de memoria está por encima del 85% durante más de 5 minutos.\n\n@slack-sre-alerts\n@email-jlsanchez.oc@gmail.com",
+            "monitor_threshold_windows": [],
+            "monitor_thresholds": [
+              {
+                "critical": "85",
+                "critical_recovery": "",
+                "ok": "",
+                "unknown": "",
+                "warning": "75",
+                "warning_recovery": ""
+              }
+            ],
+            "name": "Alta utilización de memoria en instancias EC2 - JLSO",
+            "new_group_delay": 300,
+            "new_host_delay": 300,
+            "no_data_timeframe": 0,
+            "notification_preset_name": "",
+            "notify_audit": false,
+            "notify_by": [],
+            "notify_no_data": false,
+            "on_missing_data": "",
+            "priority": "",
+            "query": "avg(last_5m):avg:system.mem.used{*} by {host} / avg:system.mem.total{*} by {host} * 100 \u003e 85",
+            "renotify_interval": 60,
+            "renotify_occurrences": 0,
+            "renotify_statuses": null,
+            "require_full_window": false,
+            "restricted_roles": null,
+            "scheduling_options": [],
+            "tags": [
+              "application:lti-project",
+              "env:production",
+              "managed-by:terraform",
+              "service:ec2",
+              "team:sre"
+            ],
+            "timeout_h": 0,
+            "type": "metric alert",
+            "validate": null,
+            "variables": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
       "type": "null_resource",
       "name": "generate_zip",
       "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
@@ -1157,9 +2414,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "4677201789009451921",
+            "id": "2541875022096482264",
             "triggers": {
-              "always_run": "2024-09-03T02:14:48Z"
+              "always_run": "2025-03-01T18:35:56Z"
             }
           },
           "sensitive_attributes": []

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,0 +1,55 @@
+# Variables para la configuración de Datadog
+
+variable "datadog_api_key" {
+  description = "API Key para Datadog"
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_app_key" {
+  description = "App Key para Datadog"
+  type        = string
+  sensitive   = true
+}
+
+variable "environment" {
+  description = "Entorno de despliegue (production, staging, development)"
+  type        = string
+  default     = "production"
+}
+
+variable "team" {
+  description = "Equipo responsable"
+  type        = string
+  default     = "sre"
+}
+
+variable "application" {
+  description = "Nombre de la aplicación"
+  type        = string
+  default     = "lti-project"
+}
+
+variable "notification_email" {
+  description = "Email para notificaciones de alertas"
+  type        = string
+  default     = "jlsanchez.oc@gmail.com"
+}
+
+variable "notification_slack" {
+  description = "Canal de Slack para notificaciones de alertas"
+  type        = string
+  default     = "sre-alerts"
+}
+
+variable "datadog_site" {
+  description = "Site de Datadog (datadoghq.com, datadoghq.eu, etc.)"
+  type        = string
+  default     = "datadoghq.com"
+}
+
+variable "datadog_api_url" {
+  description = "URL de la API de Datadog"
+  type        = string
+  default     = "https://api.datadoghq.com"
+}


### PR DESCRIPTION
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/36b9ef35-64d8-4c8c-8d99-b37ed0459efb" />


Configuración de monitoreo para las instancias ec2 (backend y frontend), donde se obtienen las métricas de información importante acerca de cada instancia, como métricas de memoria y de disco. Tuve inconvenientes con las métricas de CPU que no se pudieron configurar desde datadog, posible error en permisos de acceso a logs.

Se crea archivo de prompts con las iniciales "JLSO" y readme también con estas iniciales, donde se documenta el proceso de configuración y los problemas que se presentaron durante el proceso.

Utilice el siguiente enfoque: 1 fase: hacer que funcionara la configuración que ya estaba, para que creara las instancias en mi cuenta de aws. 1 fase: implementar la monitorización a las dos instancias ec2. y por último completar la documentación de prompts y retos presentados.